### PR TITLE
[APP-1401] clear cache on update

### DIFF
--- a/modules/remediation/classes/route-base.php
+++ b/modules/remediation/classes/route-base.php
@@ -2,10 +2,7 @@
 
 namespace EA11y\Modules\Remediation\Classes;
 
-use EA11y\Classes\Database\Exceptions\Missing_Table_Exception;
 use EA11y\Classes\Rest\Route;
-use EA11y\Modules\Remediation\Database\Page_Entry;
-use EA11y\Modules\Remediation\Database\Page_Table;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -38,32 +35,5 @@ class Route_Base extends Route {
 		$valid = $this->permission_callback( $request );
 
 		return $valid && user_can( $this->current_user_id, 'manage_options' );
-	}
-
-	/**
-	 * @throws Missing_Table_Exception
-	 */
-	public function get_page_entry( $url ) {
-		$page_entry = new Page_Entry( [
-			'by' => Page_Table::URL,
-			'value' => $url,
-		] );
-		if ( ! $page_entry->exists() ) {
-			return false;
-		}
-		return $page_entry;
-	}
-
-	/**
-	 * @throws Missing_Table_Exception
-	 */
-	public function clear_cache( string $url ) : void {
-		$page = $this->get_page_entry( $url );
-		if ( ! $page ) {
-			throw new Missing_Table_Exception( 'Page entry not found' );
-		}
-
-		$page->__set( Page_Table::FULL_HTML, null );
-		$page->save();
 	}
 }

--- a/modules/remediation/components/cache-cleaner.php
+++ b/modules/remediation/components/cache-cleaner.php
@@ -30,9 +30,11 @@ class Cache_Cleaner {
 	}
 
 	public function clean_post_cache( $post_ID, $post, $update ) {
-		// Only on publish post
+		// Only on publish post for public post type
+		$post_type_object = get_post_type_object( $post->post_type );
 		if (
 			( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ||
+			( ! $post_type_object || ! $post_type_object->public ) ||
 			'publish' !== $post->post_status
 		) {
 			return;

--- a/modules/remediation/components/cache-cleaner.php
+++ b/modules/remediation/components/cache-cleaner.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace EA11y\Modules\Remediation\Components;
+
+use EA11y\Modules\Remediation\Database\Page_Entry;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Class Cache_Cleaner
+ */
+class Cache_Cleaner {
+	public function clean_taxonomy_cache( $term_id, $tt_id, $taxonomy ) {
+		// Only for public taxonomies
+		if ( ! in_array( $taxonomy, get_taxonomies( [ 'public' => true ] ), true ) ) {
+			return;
+		}
+
+		$term = get_term( $term_id, $taxonomy );
+		$term_url = get_term_link( $term );
+
+		if ( is_wp_error( $term_url ) ) {
+			return;
+		}
+
+		$url_trimmed = rtrim( $term_url, '/' );
+		Page_Entry::clear_cache( $url_trimmed );
+	}
+
+	public function clean_post_cache( $post_ID, $post, $update ) {
+		// Only on publish post
+		if (
+			( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ||
+			'publish' !== $post->post_status
+		) {
+			return;
+		}
+
+		$post_url = get_permalink( $post_ID );
+		$url_trimmed = rtrim( $post_url, '/' );
+		Page_Entry::clear_cache( $url_trimmed );
+	}
+
+	public function __construct() {
+		add_action( 'created_term', [ $this, 'clean_taxonomy_cache' ], 10, 3 );
+		add_action( 'edited_term', [ $this, 'clean_taxonomy_cache' ], 10, 3 );
+		add_action( 'save_post', [ $this, 'clean_post_cache' ], 10, 3 );
+	}
+}

--- a/modules/remediation/database/page-entry.php
+++ b/modules/remediation/database/page-entry.php
@@ -3,6 +3,7 @@
 namespace EA11y\Modules\Remediation\Database;
 
 use EA11y\Classes\Database\Entry;
+use EA11y\Classes\Database\Exceptions\Missing_Table_Exception;
 use EA11y\Modules\Remediation\Classes\Utils;
 use EA11y\Modules\Remediation\Exceptions\Missing_URL;
 
@@ -124,5 +125,32 @@ class Page_Entry extends Entry {
 
 	public static function get_pages() : array {
 		return Page_Table::select( '*', '1', 1000, null, '', [ Page_Table::CREATED_AT => 'desc' ] );
+	}
+
+
+	/**
+	 * @throws Missing_Table_Exception
+	 */
+	public static function get_page_entry( $url ) {
+		$page_entry = new Page_Entry( [
+			'by' => Page_Table::URL,
+			'value' => $url,
+		] );
+		if ( ! $page_entry->exists() ) {
+			return false;
+		}
+		return $page_entry;
+	}
+
+	public static function clear_cache( string $url ) : void {
+		try {
+			$page = self::get_page_entry( $url );
+			if ( $page ) {
+				$page->__set( Page_Table::FULL_HTML, null );
+				$page->save();
+			}
+		} catch ( Missing_Table_Exception $exception ) {
+			return;
+		}
 	}
 }

--- a/modules/remediation/module.php
+++ b/modules/remediation/module.php
@@ -33,6 +33,7 @@ class Module extends Module_Base {
 	public static function component_list(): array {
 		return [
 			'Remediation_Runner',
+			'Cache_Cleaner',
 		];
 	}
 

--- a/modules/remediation/rest/item.php
+++ b/modules/remediation/rest/item.php
@@ -4,6 +4,7 @@ namespace EA11y\Modules\Remediation\Rest;
 
 use EA11y\Classes\Utils as Global_Utils;
 use EA11y\Modules\Remediation\Classes\Route_Base;
+use EA11y\Modules\Remediation\Database\Page_Entry;
 use EA11y\Modules\Remediation\Database\Remediation_Entry;
 use EA11y\Modules\Remediation\Database\Remediation_Table;
 use Throwable;
@@ -54,7 +55,7 @@ class Item extends Route_Base {
 				],
 			] );
 
-			$this->clear_cache( $url );
+			Page_Entry::clear_cache( $url );
 
 			$remediation->save();
 
@@ -97,7 +98,7 @@ class Item extends Route_Base {
 			$content = $request->get_param( 'content' );
 
 			Remediation_Entry::update_remediation_content( Remediation_Table::ID, $id, $content );
-			$this->clear_cache( $url );
+			Page_Entry::clear_cache( $url );
 
 			return $this->respond_success_json( [
 				'message' => 'Remediation updated successfully',
@@ -128,7 +129,7 @@ class Item extends Route_Base {
 			$active = filter_var( $request->get_param( 'active' ), FILTER_VALIDATE_BOOLEAN );
 
 			Remediation_Entry::update_remediations_status( Remediation_Table::ID, $id, $active );
-			$this->clear_cache( $url );
+			Page_Entry::clear_cache( $url );
 
 			return $this->respond_success_json( [
 				'message' => 'Remediation status updated successfully',
@@ -157,7 +158,7 @@ class Item extends Route_Base {
 			$id = sanitize_text_field( $request->get_param( 'id' ) );
 			$url = esc_url( $request->get_param( 'url' ) );
 			Remediation_Entry::remove( Remediation_Table::ID, $id );
-			$this->clear_cache( $url );
+			Page_Entry::clear_cache( $url );
 
 			return $this->respond_success_json( [
 				'message' => 'Remediation deleted successfully',

--- a/modules/remediation/rest/items.php
+++ b/modules/remediation/rest/items.php
@@ -3,6 +3,7 @@
 namespace EA11y\Modules\Remediation\Rest;
 
 use EA11y\Modules\Remediation\Classes\Route_Base;
+use EA11y\Modules\Remediation\Database\Page_Entry;
 use EA11y\Modules\Remediation\Database\Remediation_Entry;
 use EA11y\Modules\Remediation\Database\Remediation_Table;
 use Throwable;
@@ -69,7 +70,7 @@ class Items extends Route_Base {
 			$active = filter_var( $request->get_param( 'active' ), FILTER_VALIDATE_BOOLEAN );
 
 			Remediation_Entry::update_remediations_status( Remediation_Table::URL, $url, $active );
-			$this->clear_cache( $url );
+			Page_Entry::clear_cache( $url );
 
 			return $this->respond_success_json( [
 				'message' => 'Remediations status updated successfully',
@@ -97,7 +98,7 @@ class Items extends Route_Base {
 
 			$url = esc_url( $request->get_param( 'url' ) );
 			Remediation_Entry::remove( Remediation_Table::URL, $url );
-			$this->clear_cache( $url );
+			Page_Entry::clear_cache( $url );
 
 			return $this->respond_success_json( [
 				'message' => 'Remediation deleted successfully',

--- a/modules/scanner/assets/js/utils/sort-violations.js
+++ b/modules/scanner/assets/js/utils/sort-violations.js
@@ -9,7 +9,8 @@ export const sortViolations = (violations) => {
 	violations.forEach((item) => {
 		let type = '';
 		const outer = item.node.outerHTML;
-		item.snippet = outer.slice(0, outer.indexOf('>') + 1);
+		const gtIndex = outer.indexOf('>');
+		item.snippet = gtIndex !== -1 ? outer.slice(0, gtIndex + 1) : item.snippet;
 
 		Object.keys(VIOLATION_TYPES).forEach((key) => {
 			if (VIOLATION_TYPES[key].includes(item.ruleId)) {

--- a/modules/scanner/assets/js/utils/sort-violations.js
+++ b/modules/scanner/assets/js/utils/sort-violations.js
@@ -8,6 +8,9 @@ export const sortViolations = (violations) => {
 
 	violations.forEach((item) => {
 		let type = '';
+		const outer = item.node.outerHTML;
+		item.snippet = outer.slice(0, outer.indexOf('>') + 1);
+
 		Object.keys(VIOLATION_TYPES).forEach((key) => {
 			if (VIOLATION_TYPES[key].includes(item.ruleId)) {
 				type = key;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Implements automatic cache clearing for remediation data in EA11y by moving cache management code into dedicated component-based architecture.

Main changes:
- Created new Cache_Cleaner class to automatically clear page cache when content is updated
- Moved cache clearing functionality from Route_Base to Page_Entry as static methods
- Added hooks for clearing cache when posts/terms are created or edited
- Fixed snippet generation for violation elements to properly extract opening tags

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
