### PR TITLE
[APP-1603] Add dashboard menu

### DIFF
--- a/assets/dev/js/services/mixpanel/mixpanel-events.js
+++ b/assets/dev/js/services/mixpanel/mixpanel-events.js
@@ -51,4 +51,5 @@ export const mixpanelEvents = {
 	assistantDashboardHistoryLogsButtonClicked: 'history_logs_button_clicked',
 	assistantDashboardScanCtaClicked: 'scan_cta_clicked',
 	assistantDashboardSearchTriggered: 'search_triggered',
+	scanLogActionsButtonClicked: 'scan_log_actions_button_clicked',
 };

--- a/modules/remediation/database/remediation-entry.php
+++ b/modules/remediation/database/remediation-entry.php
@@ -64,7 +64,19 @@ class Remediation_Entry extends Entry {
 	 * @return array
 	 */
 	public static function get_page_remediations( string $url, bool $total = false ) : array {
-		$where = [
+		$where = $total ? [
+			[
+				'column' => Remediation_Table::table_name() . '.' . Remediation_Table::URL,
+				'value' => $url,
+				'operator' => '=',
+				'relation_after' => 'AND',
+			],
+			[
+				'column' => Remediation_Table::table_name() . '.' . Remediation_Table::GROUP,
+				'value' => 'altText',
+				'operator' => '<>',
+			],
+		] : [
 			[
 				'column' => Remediation_Table::URL,
 				'value' => $url,

--- a/modules/scanner/assets/js/components/header/dropdown-menu.js
+++ b/modules/scanner/assets/js/components/header/dropdown-menu.js
@@ -108,7 +108,7 @@ export const DropdownMenu = () => {
 								<SettingsIcon color="disabled" />
 							</MenuItemIcon>
 							<DisabledMenuItemText>
-								{__('Manage fixes', 'pojo-accessibility')}
+								{__('Manage AI fixes', 'pojo-accessibility')}
 							</DisabledMenuItemText>
 						</MenuItem>
 					</Tooltip>
@@ -118,7 +118,7 @@ export const DropdownMenu = () => {
 							<SettingsIcon />
 						</MenuItemIcon>
 						<MenuItemText>
-							{__('Manage fixes', 'pojo-accessibility')}
+							{__('Manage AI fixes', 'pojo-accessibility')}
 						</MenuItemText>
 					</MenuItem>
 				)}

--- a/modules/scanner/assets/js/constants/index.js
+++ b/modules/scanner/assets/js/constants/index.js
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 export const TOP_BAR_LINK = '#wp-admin-bar-ea11y-scanner-wizard a';
 
 export const SCANNER_URL_PARAM = 'open-ea11y-assistant';
+export const MANAGE_URL_PARAM = 'open-ea11y-manage';
 export const ROOT_ID = 'ea11y-scanner-wizard-widget';
 
 export const CURRENT_ELEMENT_CLASS = 'ea11y-scanner-current-element';

--- a/modules/scanner/assets/js/context/scanner-wizard-context.js
+++ b/modules/scanner/assets/js/context/scanner-wizard-context.js
@@ -4,6 +4,7 @@ import {
 	BLOCK_TITLES,
 	BLOCKS,
 	INITIAL_SORTED_VIOLATIONS,
+	MANAGE_URL_PARAM,
 	MANUAL_GROUPS,
 } from '@ea11y-apps/scanner/constants';
 import { scannerWizard } from '@ea11y-apps/scanner/services/scanner-wizard';
@@ -225,6 +226,14 @@ export const ScannerWizardContextProvider = ({ children }) => {
 			setLoading(false);
 		}
 	}, [window.ea11yScannerData?.isConnected]);
+
+	useEffect(() => {
+		const params = new URLSearchParams(window.location.search);
+		if (params.get(MANAGE_URL_PARAM) === '1') {
+			setIsManage(true);
+			handleOpenBlock(BLOCKS.management);
+		}
+	}, [window.location.search]);
 
 	const isResolved = (block) => {
 		const indexes = Array.from(

--- a/modules/scanner/assets/js/index.js
+++ b/modules/scanner/assets/js/index.js
@@ -8,6 +8,7 @@ import { NotificationsProvider } from '@ea11y-apps/global/hooks/use-notification
 import App from '@ea11y-apps/scanner/app';
 import {
 	isRTL,
+	MANAGE_URL_PARAM,
 	ROOT_ID,
 	SCANNER_URL_PARAM,
 	TOP_BAR_LINK,
@@ -33,7 +34,10 @@ document.addEventListener('DOMContentLoaded', function () {
 			initApp();
 		}
 	});
-	if (params.get(SCANNER_URL_PARAM) === '1') {
+	if (
+		params.get(SCANNER_URL_PARAM) === '1' ||
+		params.get(MANAGE_URL_PARAM) === '1'
+	) {
 		initApp();
 	}
 });

--- a/modules/scanner/assets/js/utils/close-widget.js
+++ b/modules/scanner/assets/js/utils/close-widget.js
@@ -6,6 +6,7 @@ export const closeWidget = (widget) => {
 	widget.remove();
 	const url = new URL(window.location.href);
 	url.searchParams.delete('open-ea11y-assistant');
+	url.searchParams.delete('open-ea11y-manage');
 	url.searchParams.delete('open-ea11y-assistant-src');
 	document.body.style.removeProperty(isRTL ? 'margin-left' : 'margin-right');
 	document.body.prepend(window.ea11yScannerData.adminBar);

--- a/modules/scanner/rest/scanner-results.php
+++ b/modules/scanner/rest/scanner-results.php
@@ -71,7 +71,7 @@ class Scanner_Results extends Route_Base {
 					'page_url' => $page->url,
 					'scans' => $scans,
 					'last_scan' => $scans[0]['date'] ?: $page->created_at,
-					'remediation_count' => $page_remediation_count[0]->total,
+					'remediation_count' => isset( $page_remediation_count[0] ) ? $page_remediation_count[0]->total : 0,
 					'issues_total' => $page->violations,
 					'issues_fixed' => $page->resolved,
 				];

--- a/modules/scanner/rest/scanner-results.php
+++ b/modules/scanner/rest/scanner-results.php
@@ -3,6 +3,7 @@
 namespace EA11y\Modules\Scanner\Rest;
 
 use EA11y\Modules\Remediation\Database\Page_Entry;
+use EA11y\Modules\Remediation\Database\Remediation_Entry;
 use EA11y\Modules\Scanner\Classes\Route_Base;
 use EA11y\Modules\Scanner\Database\Scan_Entry;
 use Throwable;
@@ -43,6 +44,7 @@ class Scanner_Results extends Route_Base {
 
 			foreach ( $pages_scanned as $page ) {
 				$scans = Scan_Entry::get_scans( $page->url );
+				$page_remediation_count = Remediation_Entry::get_page_remediations( $page->url, true );
 
 				$scans = array_map(function( $scan ) {
 					return [
@@ -69,6 +71,7 @@ class Scanner_Results extends Route_Base {
 					'page_url' => $page->url,
 					'scans' => $scans,
 					'last_scan' => $scans[0]['date'] ?: $page->created_at,
+					'remediation_count' => $page_remediation_count[0]->total,
 					'issues_total' => $page->violations,
 					'issues_fixed' => $page->resolved,
 				];

--- a/modules/settings/assets/js/pages/assistant/results/cta.js
+++ b/modules/settings/assets/js/pages/assistant/results/cta.js
@@ -1,4 +1,5 @@
 import RefreshIcon from '@elementor/icons/RefreshIcon';
+import { styled } from '@elementor/ui/styles';
 import PropTypes from 'prop-types';
 import Button from '@ea11y/components/button';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
@@ -20,7 +21,7 @@ const AccessibilityAssistantResultsTableCTA = ({ percentage, pageUrl }) => {
 
 	if (percentage === 100) {
 		return (
-			<Button
+			<StyledButton
 				size="small"
 				color="secondary"
 				variant="outlined"
@@ -31,21 +32,22 @@ const AccessibilityAssistantResultsTableCTA = ({ percentage, pageUrl }) => {
 				endIcon={<RefreshIcon />}
 			>
 				{__('New scan', 'pojo-accessibility')}
-			</Button>
+			</StyledButton>
 		);
 	}
 
 	return (
-		<Button
+		<StyledButton
 			size="small"
 			color="secondary"
 			variant="outlined"
 			href={ctaUrl}
 			onClick={() => sendAnalytics('fix_issues')}
 			target="_blank"
+			rel="noreferrer"
 		>
 			{__('Resolve issues', 'pojo-accessibility')}
-		</Button>
+		</StyledButton>
 	);
 };
 
@@ -53,5 +55,9 @@ AccessibilityAssistantResultsTableCTA.propTypes = {
 	percentage: PropTypes.number.isRequired,
 	pageUrl: PropTypes.string.isRequired,
 };
+
+const StyledButton = styled(Button)`
+	min-width: 115px;
+`;
 
 export default AccessibilityAssistantResultsTableCTA;

--- a/modules/settings/assets/js/pages/assistant/results/cta.js
+++ b/modules/settings/assets/js/pages/assistant/results/cta.js
@@ -1,5 +1,4 @@
 import RefreshIcon from '@elementor/icons/RefreshIcon';
-import { styled } from '@elementor/ui/styles';
 import PropTypes from 'prop-types';
 import Button from '@ea11y/components/button';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
@@ -21,22 +20,23 @@ const AccessibilityAssistantResultsTableCTA = ({ percentage, pageUrl }) => {
 
 	if (percentage === 100) {
 		return (
-			<StyledButton
+			<Button
 				size="small"
 				color="secondary"
 				variant="outlined"
 				href={ctaUrl}
 				onClick={() => sendAnalytics('rescan_url')}
 				target="_blank"
+				rel="noreferrer"
 				endIcon={<RefreshIcon />}
 			>
 				{__('New scan', 'pojo-accessibility')}
-			</StyledButton>
+			</Button>
 		);
 	}
 
 	return (
-		<StyledButton
+		<Button
 			size="small"
 			color="secondary"
 			variant="outlined"
@@ -45,7 +45,7 @@ const AccessibilityAssistantResultsTableCTA = ({ percentage, pageUrl }) => {
 			target="_blank"
 		>
 			{__('Resolve issues', 'pojo-accessibility')}
-		</StyledButton>
+		</Button>
 	);
 };
 
@@ -53,9 +53,5 @@ AccessibilityAssistantResultsTableCTA.propTypes = {
 	percentage: PropTypes.number.isRequired,
 	pageUrl: PropTypes.string.isRequired,
 };
-
-const StyledButton = styled(Button)`
-	margin-inline-start: ${({ theme }) => theme.spacing(2)};
-`;
 
 export default AccessibilityAssistantResultsTableCTA;

--- a/modules/settings/assets/js/pages/assistant/results/dropdown-menu.js
+++ b/modules/settings/assets/js/pages/assistant/results/dropdown-menu.js
@@ -113,7 +113,7 @@ export const DropdownMenu = ({ pageUrl, remediationCount }) => {
 								<SettingsIcon color="disabled" />
 							</MenuItemIcon>
 							<DisabledMenuItemText>
-								{__('Manage fixes', 'pojo-accessibility')}
+								{__('Manage AI fixes', 'pojo-accessibility')}
 							</DisabledMenuItemText>
 						</MenuItem>
 					</Tooltip>
@@ -129,7 +129,7 @@ export const DropdownMenu = ({ pageUrl, remediationCount }) => {
 							<SettingsIcon />
 						</MenuItemIcon>
 						<MenuItemText>
-							{__('Manage fixes', 'pojo-accessibility')}
+							{__('Manage AI fixes', 'pojo-accessibility')}
 						</MenuItemText>
 					</MenuItem>
 				)}

--- a/modules/settings/assets/js/pages/assistant/results/dropdown-menu.js
+++ b/modules/settings/assets/js/pages/assistant/results/dropdown-menu.js
@@ -1,0 +1,144 @@
+import DotsHorizontalIcon from '@elementor/icons/DotsHorizontalIcon';
+import RefreshIcon from '@elementor/icons/RefreshIcon';
+import SettingsIcon from '@elementor/icons/SettingsIcon';
+import Box from '@elementor/ui/Box';
+import IconButton from '@elementor/ui/IconButton';
+import Menu from '@elementor/ui/Menu';
+import MenuItem from '@elementor/ui/MenuItem';
+import MenuItemIcon from '@elementor/ui/MenuItemIcon';
+import MenuItemText from '@elementor/ui/MenuItemText';
+import Tooltip from '@elementor/ui/Tooltip';
+import PropTypes from 'prop-types';
+import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
+import { DisabledMenuItemText } from '@ea11y-apps/scanner/styles/app.styles';
+import { useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+export const DropdownMenu = ({ pageUrl, remediationCount }) => {
+	const [isOpened, setIsOpened] = useState(false);
+	const anchorEl = useRef(null);
+
+	const ctaScan = addQueryArgs(pageUrl, {
+		'open-ea11y-assistant': '1',
+		'open-ea11y-assistant-src': 'Ally_dashboard',
+	});
+
+	const ctaManage = addQueryArgs(pageUrl, {
+		'open-ea11y-manage': '1',
+		'open-ea11y-assistant-src': 'Ally_dashboard',
+	});
+
+	const handleOpen = () => setIsOpened(true);
+	const handleClose = () => setIsOpened(false);
+
+	const sendOnClickEvent = (action) => {
+		mixpanelService.sendEvent(mixpanelEvents.scanLogActionsButtonClicked, {
+			action,
+		});
+	};
+
+	const onRunNewScan = () => {
+		sendOnClickEvent('scan');
+	};
+
+	const goToManagement = () => {
+		handleClose();
+		sendOnClickEvent('manage fixes');
+	};
+
+	return (
+		<Box>
+			<IconButton
+				id="menu-button"
+				aria-controls={isOpened ? 'assistant-menu' : undefined}
+				aria-expanded={isOpened ? 'true' : undefined}
+				aria-haspopup="true"
+				onClick={handleOpen}
+				ref={anchorEl}
+				aria-label={__('Menu', 'pojo-accessibility')}
+			>
+				<DotsHorizontalIcon />
+			</IconButton>
+			<Menu
+				open={isOpened}
+				id="assistant-menu"
+				anchorEl={anchorEl.current}
+				container={anchorEl.current}
+				onClose={handleClose}
+				MenuListProps={{
+					'aria-labelledby': 'menu-button',
+				}}
+				PaperProps={{
+					style: {
+						overflow: 'visible',
+					},
+				}}
+				disablePortal
+			>
+				<MenuItem
+					component="a"
+					href={ctaScan}
+					target="_blank"
+					rel="noreferrer"
+					onClick={onRunNewScan}
+				>
+					<MenuItemIcon>
+						<RefreshIcon />
+					</MenuItemIcon>
+					<MenuItemText>{__('New Scan', 'pojo-accessibility')}</MenuItemText>
+				</MenuItem>
+				{remediationCount < 1 ? (
+					<Tooltip
+						arrow
+						placement="left"
+						title={__(
+							'You don’t have any fixes to manage just yet.',
+							'pojo-accessibility',
+						)}
+						PopperProps={{
+							disablePortal: true,
+							modifiers: [
+								{
+									name: 'offset',
+									options: {
+										offset: [0, -16],
+									},
+								},
+							],
+						}}
+					>
+						<MenuItem>
+							<MenuItemIcon>
+								<SettingsIcon color="disabled" />
+							</MenuItemIcon>
+							<DisabledMenuItemText>
+								{__('Manage fixes', 'pojo-accessibility')}
+							</DisabledMenuItemText>
+						</MenuItem>
+					</Tooltip>
+				) : (
+					<MenuItem
+						component="a"
+						href={ctaManage}
+						target="_blank"
+						rel="noreferrer"
+						onClick={goToManagement}
+					>
+						<MenuItemIcon>
+							<SettingsIcon />
+						</MenuItemIcon>
+						<MenuItemText>
+							{__('Manage fixes', 'pojo-accessibility')}
+						</MenuItemText>
+					</MenuItem>
+				)}
+			</Menu>
+		</Box>
+	);
+};
+
+DropdownMenu.propTypes = {
+	pageUrl: PropTypes.string.isRequired,
+	remediationCount: PropTypes.number.isRequired,
+};

--- a/modules/settings/assets/js/pages/assistant/results/table.js
+++ b/modules/settings/assets/js/pages/assistant/results/table.js
@@ -17,12 +17,13 @@ import Button from '@ea11y/components/button';
 import VisuallyHidden from '@ea11y/components/visually-hidden';
 import TableLoader from '@ea11y/pages/assistant/loaders/table-loader';
 import AccessibilityAssistantResultsTableCTA from '@ea11y/pages/assistant/results/cta';
+import { DropdownMenu } from '@ea11y/pages/assistant/results/dropdown-menu';
 import AccessibilityAssistantResultsPagination from '@ea11y/pages/assistant/results/pagination';
 import AccessibilityAssistantResultsTableProgressChip from '@ea11y/pages/assistant/results/progress-chip';
 import AccessibilityAssistantTooltip from '@ea11y/pages/assistant/tooltip';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { dateI18n } from '@wordpress/date';
-import { Fragment, useState, forwardRef } from '@wordpress/element';
+import { forwardRef, Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const AccessibilityAssistantResultsTable = ({ scannerResults, loading }) => {
@@ -142,6 +143,11 @@ const AccessibilityAssistantResultsTable = ({ scannerResults, loading }) => {
 												percentage={resolvedPercentage}
 												pageUrl={result.page_url}
 											/>
+
+											<DropdownMenu
+												pageUrl={result.page_url}
+												remediationCount={result.remediation_count}
+											/>
 										</StyledControlsContainer>
 									</TableCell>
 								</TableRow>
@@ -213,6 +219,7 @@ const StyledControlsContainer = styled(Box)`
 	display: flex;
 	align-items: center;
 	justify-content: flex-end;
+	gap: ${({ theme }) => theme.spacing(2)};
 `;
 
 const ForwardedButton = forwardRef((props, ref) => (


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Adds support for managing AI fixes from the dashboard by implementing a dropdown menu with direct access to remediation management.

Main changes:
- Adds URL parameter 'open-ea11y-manage' to open accessibility widget in management mode
- Modifies get_page_remediations to filter out altText remediations when counting total remediation items
- Creates dropdown menu component for scan logs with actions to manage AI fixes
- Adds new mixpanel event 'scan_log_actions_button_clicked' for tracking remediation management actions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
