### PR TITLE
[APP-1678] Remove mixpanel session replay

### DIFF
--- a/modules/settings/assets/js/services/mixpanel-service.js
+++ b/modules/settings/assets/js/services/mixpanel-service.js
@@ -18,7 +18,6 @@ const init = async () => {
 		debug: ea11ySettingsData.pluginEnv === 'dev',
 		track_pageview: false,
 		persistence: 'localStorage',
-		record_sessions_percent: 50,
 	});
 
 	mixpanel.register({


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Removed record_sessions_percent parameter from Mixpanel initialization to adjust tracking configuration.

Main changes:
- Removed record_sessions_percent: 50 parameter from mixpanel.init options

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
