### PR TITLE
[APP-0000] call trigger save async

### DIFF
--- a/modules/scanner/assets/js/components/header/index.js
+++ b/modules/scanner/assets/js/components/header/index.js
@@ -39,7 +39,7 @@ export const Header = () => {
 		setIsManage,
 	} = useScannerWizardContext();
 	const violation = results?.summary?.counts?.violation;
-	const onClose = async () => {
+	const onClose = () => {
 		if (isManage) {
 			setIsManage(false);
 			setOpenedBlock(BLOCKS.main);
@@ -47,14 +47,10 @@ export const Header = () => {
 			const widget = document.getElementById(ROOT_ID);
 			closeWidget(widget);
 			if (isChanged) {
-				try {
-					await APIScanner.triggerSave({
-						object_id: window?.ea11yScannerData?.pageData?.object_id,
-						object_type: window?.ea11yScannerData?.pageData?.object_type,
-					});
-				} catch (e) {
-					console.warn(e);
-				}
+				void APIScanner.triggerSave({
+					object_id: window?.ea11yScannerData?.pageData?.object_id,
+					object_type: window?.ea11yScannerData?.pageData?.object_type,
+				});
 			}
 		}
 	};

--- a/modules/scanner/assets/js/context/scanner-wizard-context.js
+++ b/modules/scanner/assets/js/context/scanner-wizard-context.js
@@ -179,10 +179,12 @@ export const ScannerWizardContextProvider = ({ children }) => {
 
 	const addScanResults = async (data) => {
 		try {
-			const response = await APIScanner.addScanResults({
-				url: window?.ea11yScannerData?.pageData?.url,
+			void APIScanner.triggerSave({
 				object_id: window?.ea11yScannerData?.pageData?.object_id,
 				object_type: window?.ea11yScannerData?.pageData?.object_type,
+			});
+			const response = await APIScanner.addScanResults({
+				url: window?.ea11yScannerData?.pageData?.url,
 				summary: data.summary,
 			});
 

--- a/modules/scanner/rest/scan-results.php
+++ b/modules/scanner/rest/scan-results.php
@@ -3,7 +3,6 @@
 namespace EA11y\Modules\Scanner\Rest;
 
 use EA11y\Classes\Utils as Global_Utils;
-use EA11y\Modules\Remediation\Classes\Utils;
 use EA11y\Modules\Remediation\Database\Page_Entry;
 use EA11y\Modules\Remediation\Database\Page_Table;
 use EA11y\Modules\Scanner\Classes\Route_Base;
@@ -43,8 +42,6 @@ class Scan_Results extends Route_Base {
 
 			$url = esc_url_raw( $request->get_param( 'url' ) );
 			$summary = Global_Utils::sanitize_object( $request->get_param( 'summary' ) );
-			$object_id = sanitize_text_field( $request->get_param( 'object_id' ) );
-			$object_type = sanitize_text_field( $request->get_param( 'object_type' ) );
 
 			$scan = new Scan_Entry([
 				'data' => [
@@ -60,8 +57,6 @@ class Scan_Results extends Route_Base {
 			$page->update_stats( $summary['counts']['violation'] );
 
 			$scan->save();
-
-			Utils::trigger_save_for_clean_cache( $object_id, $object_type );
 
 			return $this->respond_success_json( [
 				'message' => 'Scan results added',


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Optimizes scanner save operations by moving the triggerSave API call to a unified void function in the accessibility scanner module.

Main changes:
- Changed onClose function to use void for API calls instead of async/await
- Modified addScanResults to use void syntax for triggerSave before scan results save
- Removed Utils::trigger_save_for_clean_cache call from PHP scan-results endpoint

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
