### PR TITLE
Fix: Resolve remediation encoding issue [APP-1646]

### DIFF
--- a/modules/remediation/actions/replace.php
+++ b/modules/remediation/actions/replace.php
@@ -17,7 +17,6 @@ class Replace extends Remediation_Base {
 	public static string $type = 'replace';
 
 	public function run() : ?DOMDocument {
-
 		$element_node = $this->get_element_by_xpath( $this->data['xpath'] );
 		if ( ! $element_node instanceof \DOMElement ) {
 			return null;                    // nothing to do
@@ -35,9 +34,9 @@ class Replace extends Remediation_Base {
 			return $this->dom;
 		}
 
-		$tmp_dom = new DOMDocument();
+		$tmp_dom = new DOMDocument('1.0', 'UTF-8');
 		$tmp_dom->loadHTML(
-			$updated_html,
+			mb_convert_encoding($updated_html, 'HTML-ENTITIES', 'UTF-8'),
 			LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOERROR | LIBXML_NOWARNING
 		);
 

--- a/modules/remediation/components/remediation-runner.php
+++ b/modules/remediation/components/remediation-runner.php
@@ -83,7 +83,7 @@ class Remediation_Runner {
 	}
 
 	private function generate_remediation_dom( $buffer ): string {
-		$dom = new DOMDocument();
+		$dom = new DOMDocument('1.0', 'UTF-8');
 		$dom->loadHTML( $buffer, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOERROR );
 
 		//Remove admin-bar for correct replace


### PR DESCRIPTION
`DOMDocument` defaults to latin1 if can't define an encoding from the headers/meta tags. Manually defining UTF-8 resolves the issue.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fixed character encoding issues in DOMDocument handling for the Remediation module by specifying UTF-8 encoding parameters.

Main changes:
- Added encoding parameters ('1.0', 'UTF-8') to DOMDocument constructor in multiple files
- Added mb_convert_encoding to properly handle UTF-8 characters in HTML content
- Removed unnecessary empty line in Replace class run() method

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
