### PR TITLE
[APP-1611] add litespeed clear cache hook

### DIFF
--- a/modules/remediation/classes/utils.php
+++ b/modules/remediation/classes/utils.php
@@ -2,6 +2,8 @@
 
 namespace EA11y\Modules\Remediation\Classes;
 
+use EA11y\Modules\Remediation\Components\Cache_Cleaner;
+
 class Utils {
 	/**
 	 * get current page url
@@ -132,6 +134,7 @@ class Utils {
 		if ( in_array( $entry_type, $post_types, true ) ) {
 			$post = get_post( $entry_id );
 			if ( $post && is_object( $post ) && 'publish' === $post->post_status ) {
+				do_action( Cache_Cleaner::EA11Y_CLEAR_POST_CACHE_HOOK, $entry_id );
 				do_action( 'save_post', $entry_id, $post, true );
 			}
 		}

--- a/modules/remediation/classes/utils.php
+++ b/modules/remediation/classes/utils.php
@@ -134,7 +134,7 @@ class Utils {
 		if ( in_array( $entry_type, $post_types, true ) ) {
 			$post = get_post( $entry_id );
 			if ( $post && is_object( $post ) && 'publish' === $post->post_status ) {
-				do_action( Cache_Cleaner::EA11Y_CLEAR_POST_CACHE_HOOK, $entry_id );
+				do_action( Cache_Cleaner::EA11Y_CLEAR_POST_CACHE_HOOK, $entry_id, $post );
 				do_action( 'save_post', $entry_id, $post, true );
 			}
 		}

--- a/modules/remediation/components/cache-cleaner.php
+++ b/modules/remediation/components/cache-cleaner.php
@@ -12,6 +12,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Cache_Cleaner
  */
 class Cache_Cleaner {
+	const EA11Y_CLEAR_POST_CACHE_HOOK = 'ea11y_clear_post_cache';
+
+	public function add_litespeed_clean_hook() {
+		add_filter( 'litespeed_purge_post_events', function ( $events ) {
+			$events[] = self::EA11Y_CLEAR_POST_CACHE_HOOK; // Add your custom hook
+			return $events;
+		} );
+	}
+
 	public function clean_taxonomy_cache( $term_id, $tt_id, $taxonomy ) {
 		// Only for public taxonomies
 		if ( ! in_array( $taxonomy, get_taxonomies( [ 'public' => true ] ), true ) ) {
@@ -46,6 +55,7 @@ class Cache_Cleaner {
 	}
 
 	public function __construct() {
+		$this->add_litespeed_clean_hook();
 		add_action( 'created_term', [ $this, 'clean_taxonomy_cache' ], 10, 3 );
 		add_action( 'edited_term', [ $this, 'clean_taxonomy_cache' ], 10, 3 );
 		add_action( 'save_post', [ $this, 'clean_post_cache' ], 10, 3 );

--- a/modules/remediation/components/cache-cleaner.php
+++ b/modules/remediation/components/cache-cleaner.php
@@ -16,7 +16,7 @@ class Cache_Cleaner {
 
 	public function add_litespeed_clean_hook() {
 		add_filter( 'litespeed_purge_post_events', function ( $events ) {
-			$events[] = self::EA11Y_CLEAR_POST_CACHE_HOOK; // Add your custom hook
+			$events[] = self::EA11Y_CLEAR_POST_CACHE_HOOK;
 			return $events;
 		} );
 	}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Adds LiteSpeed cache integration to EA11y Remediation Module by creating custom hooks for cache clearing.

Main changes:
- Created EA11Y_CLEAR_POST_CACHE_HOOK constant for standardizing cache clearing events
- Added add_litespeed_clean_hook() method to register EA11y's hook with LiteSpeed
- Implemented hook trigger in trigger_save_for_clean_cache() before save_post action

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
