### PR TITLE
[APP-1697] fix menu, add category to events as key without translation

### DIFF
--- a/modules/scanner/assets/js/components/header/dropdown-menu.js
+++ b/modules/scanner/assets/js/components/header/dropdown-menu.js
@@ -67,6 +67,8 @@ export const DropdownMenu = () => {
 				anchorEl={anchorEl.current}
 				container={anchorEl.current}
 				onClose={handleClose}
+				anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+				transformOrigin={{ vertical: 'top', horizontal: 'right' }}
 				MenuListProps={{
 					'aria-labelledby': 'menu-button',
 				}}
@@ -77,7 +79,7 @@ export const DropdownMenu = () => {
 				}}
 				disablePortal
 			>
-				<MenuItem onClick={onRunNewScan}>
+				<MenuItem onClick={onRunNewScan} dense>
 					<MenuItemIcon>
 						<RefreshIcon />
 					</MenuItemIcon>
@@ -103,7 +105,7 @@ export const DropdownMenu = () => {
 							],
 						}}
 					>
-						<MenuItem>
+						<MenuItem dense>
 							<MenuItemIcon>
 								<SettingsIcon color="disabled" />
 							</MenuItemIcon>
@@ -117,6 +119,7 @@ export const DropdownMenu = () => {
 						onClick={goToManagement}
 						disabled={isManage}
 						selected={isManage}
+						dense
 					>
 						<MenuItemIcon>
 							<SettingsIcon />
@@ -133,6 +136,7 @@ export const DropdownMenu = () => {
 					target="_blank"
 					rel="noreferrer"
 					onClick={() => sendOnClickEvent('View subscription')}
+					dense
 				>
 					<MenuItemIcon>
 						<CalendarDollarIcon />

--- a/modules/scanner/assets/js/components/manual-fix-form/index.js
+++ b/modules/scanner/assets/js/components/manual-fix-form/index.js
@@ -15,11 +15,7 @@ import { useToastNotification } from '@ea11y-apps/global/hooks';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { APIScanner } from '@ea11y-apps/scanner/api/APIScanner';
 import { ResolveWithAi } from '@ea11y-apps/scanner/components/manual-fix-form/resolve-with-ai';
-import {
-	BLOCK_TITLES,
-	BLOCKS,
-	EXCLUDE_FROM_AI,
-} from '@ea11y-apps/scanner/constants';
+import { BLOCKS, EXCLUDE_FROM_AI } from '@ea11y-apps/scanner/constants';
 import { uxMessaging } from '@ea11y-apps/scanner/constants/ux-messaging';
 import { useScannerWizardContext } from '@ea11y-apps/scanner/context/scanner-wizard-context';
 import { useCopyToClipboard } from '@ea11y-apps/scanner/hooks/use-copy-to-clipboard';
@@ -54,7 +50,7 @@ export const ManualFixForm = ({ item, current, setOpen }) => {
 
 	const sendMixpanelEvent = (event) => {
 		mixpanelService.sendEvent(event, {
-			category_name: BLOCK_TITLES[openedBlock],
+			category_name: openedBlock,
 			issue_type: item.message,
 			element_selector: item.path.dom,
 		});

--- a/modules/scanner/assets/js/components/manual-fix-form/resolve-with-ai.js
+++ b/modules/scanner/assets/js/components/manual-fix-form/resolve-with-ai.js
@@ -14,11 +14,7 @@ import Typography from '@elementor/ui/Typography';
 import PropTypes from 'prop-types';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { UpgradeInfoTip } from '@ea11y-apps/scanner/components/upgrade-info-tip';
-import {
-	AI_QUOTA_LIMIT,
-	BLOCK_TITLES,
-	IS_AI_ENABLED,
-} from '@ea11y-apps/scanner/constants';
+import { AI_QUOTA_LIMIT, IS_AI_ENABLED } from '@ea11y-apps/scanner/constants';
 import { useScannerWizardContext } from '@ea11y-apps/scanner/context/scanner-wizard-context';
 import { useCopyToClipboard } from '@ea11y-apps/scanner/hooks/use-copy-to-clipboard';
 import { useManualFixForm } from '@ea11y-apps/scanner/hooks/use-manual-fix-form';
@@ -60,7 +56,7 @@ export const ResolveWithAi = ({ item, current }) => {
 		setIsEdit(true);
 		mixpanelService.sendEvent(mixpanelEvents.editSnippetClicked, {
 			snippet_content: aiSuggestion.snippet,
-			category_name: BLOCK_TITLES[openedBlock],
+			category_name: openedBlock,
 			source: 'assistant',
 		});
 	};
@@ -74,7 +70,7 @@ export const ResolveWithAi = ({ item, current }) => {
 				issue_type: item.message,
 				rule_id: item.ruleId,
 				wcag_level: item.reasonCategory.match(/\((AAA?|AA?|A)\)/)?.[1] || '',
-				category_name: BLOCK_TITLES[openedBlock],
+				category_name: openedBlock,
 				// ai_text_response: text,
 			});
 		} else {

--- a/modules/scanner/assets/js/context/scanner-wizard-context.js
+++ b/modules/scanner/assets/js/context/scanner-wizard-context.js
@@ -137,7 +137,7 @@ export const ScannerWizardContextProvider = ({ children }) => {
 				issue_type: item.message,
 				rule_id: item.ruleId,
 				wcag_level: item.reasonCategory.match(/\((AAA?|AA?|A)\)/)?.[1] || '',
-				category_name: BLOCKS[openedBlock],
+				category_name: openedBlock,
 			});
 		}
 	};

--- a/modules/scanner/assets/js/context/scanner-wizard-context.js
+++ b/modules/scanner/assets/js/context/scanner-wizard-context.js
@@ -1,7 +1,6 @@
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { APIScanner } from '@ea11y-apps/scanner/api/APIScanner';
 import {
-	BLOCK_TITLES,
 	BLOCKS,
 	INITIAL_SORTED_VIOLATIONS,
 	MANAGE_URL_PARAM,
@@ -138,7 +137,7 @@ export const ScannerWizardContextProvider = ({ children }) => {
 				issue_type: item.message,
 				rule_id: item.ruleId,
 				wcag_level: item.reasonCategory.match(/\((AAA?|AA?|A)\)/)?.[1] || '',
-				category_name: BLOCK_TITLES[openedBlock],
+				category_name: BLOCKS[openedBlock],
 			});
 		}
 	};

--- a/modules/scanner/assets/js/hooks/use-alt-text-form.js
+++ b/modules/scanner/assets/js/hooks/use-alt-text-form.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { useToastNotification } from '@ea11y-apps/global/hooks';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { APIScanner } from '@ea11y-apps/scanner/api/APIScanner';
-import { BLOCK_TITLES, BLOCKS } from '@ea11y-apps/scanner/constants';
+import { BLOCKS } from '@ea11y-apps/scanner/constants';
 import { useScannerWizardContext } from '@ea11y-apps/scanner/context/scanner-wizard-context';
 import { scannerItem } from '@ea11y-apps/scanner/types/scanner-item';
 import { removeExistingFocus } from '@ea11y-apps/scanner/utils/focus-on-element';
@@ -115,7 +115,7 @@ export const useAltTextForm = ({ current, item }) => {
 		});
 		if (e.target.checked) {
 			mixpanelService.sendEvent(mixpanelEvents.markAsDecorativeSelected, {
-				category_name: BLOCK_TITLES[BLOCKS.altText],
+				category_name: BLOCKS.altText,
 			});
 		}
 	};
@@ -151,7 +151,7 @@ export const useAltTextForm = ({ current, item }) => {
 				? 'Mark as decorative'
 				: fixMethod,
 			issue_type: item.message,
-			category_name: BLOCK_TITLES[BLOCKS.altText],
+			category_name: BLOCKS.altText,
 		});
 	};
 
@@ -169,7 +169,7 @@ export const useAltTextForm = ({ current, item }) => {
 			issue_type: item.message,
 			rule_id: item.ruleId,
 			wcag_level: item.reasonCategory.match(/\((AAA?|AA?|A)\)/)?.[1] || '',
-			category_name: BLOCK_TITLES[BLOCKS.altText],
+			category_name: BLOCKS.altText,
 			ai_text_response: text,
 		});
 	};

--- a/modules/scanner/assets/js/hooks/use-copy-to-clipboard.js
+++ b/modules/scanner/assets/js/hooks/use-copy-to-clipboard.js
@@ -1,6 +1,5 @@
 import clipboardCopy from 'clipboard-copy';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
-import { BLOCK_TITLES } from '@ea11y-apps/scanner/constants';
 import { useScannerWizardContext } from '@ea11y-apps/scanner/context/scanner-wizard-context';
 import { useState } from '@wordpress/element';
 
@@ -14,7 +13,7 @@ export const useCopyToClipboard = () => {
 		mixpanelService.sendEvent(mixpanelEvents.copySnippetClicked, {
 			snippet_type: type,
 			snippet_content: snippet,
-			category_name: BLOCK_TITLES[openedBlock],
+			category_name: openedBlock,
 			source,
 		});
 	};

--- a/modules/scanner/assets/js/hooks/use-manage-actions.js
+++ b/modules/scanner/assets/js/hooks/use-manage-actions.js
@@ -1,7 +1,6 @@
 import { useToastNotification } from '@ea11y-apps/global/hooks';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { APIScanner } from '@ea11y-apps/scanner/api/APIScanner';
-import { BLOCK_TITLES } from '@ea11y-apps/scanner/constants';
 import { useScannerWizardContext } from '@ea11y-apps/scanner/context/scanner-wizard-context';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -90,7 +89,7 @@ export const useManageActions = (current = null) => {
 				mixpanelEvents[active ? 'remediationEnabled' : 'remediationDisabled'],
 				{
 					action_type: active ? 'enable_specific' : 'disable_specific',
-					category_name: BLOCK_TITLES[openedBlock],
+					category_name: openedBlock,
 					issue_type: current.rule,
 				},
 			);
@@ -119,7 +118,7 @@ export const useManageActions = (current = null) => {
 			setIsManageChanged(true);
 			mixpanelService.sendEvent(mixpanelEvents.remediationRemoved, {
 				action_type: 'remove_specific',
-				category_name: BLOCK_TITLES[openedBlock],
+				category_name: openedBlock,
 				issue_type: current.rule,
 			});
 		} catch (e) {
@@ -150,7 +149,7 @@ export const useManageActions = (current = null) => {
 			mixpanelService.sendEvent(mixpanelEvents.applyFixButtonClicked, {
 				fix_method: 'manual',
 				snippet_content: strContent,
-				category_name: BLOCK_TITLES[openedBlock],
+				category_name: openedBlock,
 				source: 'remediation',
 			});
 		} catch (e) {

--- a/modules/scanner/assets/js/hooks/use-manual-fix-form.js
+++ b/modules/scanner/assets/js/hooks/use-manual-fix-form.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { useToastNotification } from '@ea11y-apps/global/hooks';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { APIScanner } from '@ea11y-apps/scanner/api/APIScanner';
-import { BLOCK_TITLES, BLOCKS } from '@ea11y-apps/scanner/constants';
+import { BLOCKS } from '@ea11y-apps/scanner/constants';
 import { useScannerWizardContext } from '@ea11y-apps/scanner/context/scanner-wizard-context';
 import { scannerItem } from '@ea11y-apps/scanner/types/scanner-item';
 import { removeExistingFocus } from '@ea11y-apps/scanner/utils/focus-on-element';
@@ -102,7 +102,7 @@ export const useManualFixForm = ({ item, current }) => {
 				fix_method: manualEdit ? 'manual' : 'AI',
 				issue_type: item.message,
 				snippet_content: replace,
-				category_name: BLOCK_TITLES[openedBlock],
+				category_name: openedBlock,
 				source: 'assistant',
 			});
 

--- a/modules/scanner/assets/js/layouts/alt-text-layout.js
+++ b/modules/scanner/assets/js/layouts/alt-text-layout.js
@@ -1,7 +1,7 @@
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { AltTextForm } from '@ea11y-apps/scanner/components/alt-text-form';
 import { AltTextNavigation } from '@ea11y-apps/scanner/components/alt-text-navigation';
-import { BLOCK_TITLES, BLOCKS } from '@ea11y-apps/scanner/constants';
+import { BLOCKS } from '@ea11y-apps/scanner/constants';
 import { useScannerWizardContext } from '@ea11y-apps/scanner/context/scanner-wizard-context';
 import { StyledContent } from '@ea11y-apps/scanner/styles/app.styles';
 import {
@@ -28,7 +28,7 @@ export const AltTextLayout = () => {
 			issue_type: item.message,
 			rule_id: item.ruleId,
 			wcag_level: item.reasonCategory.match(/\((AAA?|AA?|A)\)/)?.[1] || '',
-			category_name: BLOCK_TITLES[BLOCKS.altText],
+			category_name: BLOCKS.altText,
 		});
 	}, [current]);
 

--- a/modules/settings/assets/js/pages/assistant/results/dropdown-menu.js
+++ b/modules/settings/assets/js/pages/assistant/results/dropdown-menu.js
@@ -66,6 +66,8 @@ export const DropdownMenu = ({ pageUrl, remediationCount }) => {
 				anchorEl={anchorEl.current}
 				container={anchorEl.current}
 				onClose={handleClose}
+				anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+				transformOrigin={{ vertical: 'top', horizontal: 'right' }}
 				MenuListProps={{
 					'aria-labelledby': 'menu-button',
 				}}
@@ -82,6 +84,7 @@ export const DropdownMenu = ({ pageUrl, remediationCount }) => {
 					target="_blank"
 					rel="noreferrer"
 					onClick={onRunNewScan}
+					dense
 				>
 					<MenuItemIcon>
 						<RefreshIcon />
@@ -108,7 +111,7 @@ export const DropdownMenu = ({ pageUrl, remediationCount }) => {
 							],
 						}}
 					>
-						<MenuItem>
+						<MenuItem dense>
 							<MenuItemIcon>
 								<SettingsIcon color="disabled" />
 							</MenuItemIcon>
@@ -124,6 +127,7 @@ export const DropdownMenu = ({ pageUrl, remediationCount }) => {
 						target="_blank"
 						rel="noreferrer"
 						onClick={goToManagement}
+						dense
 					>
 						<MenuItemIcon>
 							<SettingsIcon />


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
```
Purpose: Fix menu component positioning and remove translation dependency by using raw category names as keys in events tracking.
Main changes:
- Added proper menu positioning with anchorOrigin and transformOrigin props
- Added dense prop to MenuItem components for consistent menu styling
- Removed BLOCK_TITLES dependency in favor of direct category name usage in analytics events
```

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
