### PR TITLE
[APP-1724] Fix get object type for singular

### DIFF
--- a/modules/remediation/classes/utils.php
+++ b/modules/remediation/classes/utils.php
@@ -71,7 +71,7 @@ class Utils {
 
 		if ( $wp_query->is_singular() ) {
 			if ( $wp_query->is_single() ) {
-				return get_post_type() ?? 'unknown';
+                                return get_post_type($wp_query->get_queried_object_id()) ?? 'unknown';
 			} elseif ( $wp_query->is_page() ) {
 				return 'page';
 			} elseif ( $wp_query->is_attachment() ) {

--- a/modules/remediation/classes/utils.php
+++ b/modules/remediation/classes/utils.php
@@ -71,7 +71,7 @@ class Utils {
 
 		if ( $wp_query->is_singular() ) {
 			if ( $wp_query->is_single() ) {
-				return $wp_query->query_vars['post_type'] ?? 'unknown';
+				return get_post_type() ?? 'unknown';
 			} elseif ( $wp_query->is_page() ) {
 				return 'page';
 			} elseif ( $wp_query->is_attachment() ) {

--- a/modules/scanner/rest/scanner-stats.php
+++ b/modules/scanner/rest/scanner-stats.php
@@ -62,8 +62,8 @@ class Scanner_Stats extends Route_Base {
 
 				if ( count( $recent_scans ) > 0 ) {
 					$output['scans'] ++;
-					$output['issues_total'] += $recent_scans[0]->summary['counts']['violation'];
-					$output['issues_fixed'] += $recent_scans[0]->summary['counts']['issuesResolved'];
+					$output['issues_total'] += $recent_scans[0]->summary['counts']['violation'] ?? 0;
+					$output['issues_fixed'] += $recent_scans[0]->summary['counts']['issuesResolved'] ?? 0;
 				}
 			}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix post type detection for singular posts and prevent PHP errors when summary data is missing in scans.
Main changes:
- Replace query_vars with get_post_type() to correctly retrieve post types for singular posts
- Add null coalescing operators to scan summary counts to prevent undefined index errors

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
