### PR TITLE
Fix: Use the same issue count in the WP admin and scanner [APP-1726]

### DIFF
--- a/modules/scanner/assets/js/context/scanner-wizard-context.js
+++ b/modules/scanner/assets/js/context/scanner-wizard-context.js
@@ -167,8 +167,8 @@ export const ScannerWizardContextProvider = ({ children }) => {
 			setAltTextData([]);
 			setManualData(structuredClone(MANUAL_GROUPS));
 			setResolved(
-				initialViolations > data.summary?.counts?.violation
-					? initialViolations - data.summary?.counts?.violation
+				initialViolations >= data.summary?.counts?.issuesResolved
+					? data.summary?.counts?.issuesResolved
 					: 0,
 			);
 		} catch (e) {

--- a/modules/scanner/components/list-column.php
+++ b/modules/scanner/components/list-column.php
@@ -5,6 +5,7 @@ namespace EA11y\Modules\Scanner\Components;
 use EA11y\Classes\Database\Exceptions\Missing_Table_Exception;
 use EA11y\Modules\Remediation\Database\Page_Entry;
 use EA11y\Modules\Remediation\Database\Page_Table;
+use EA11y\Modules\Scanner\Database\Scan_Entry;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -63,8 +64,9 @@ class List_Column {
 		$url_trimmed = rtrim( $url, '/' );
 		$page = $this->get_current_page( $url_trimmed );
 		$has_scan_data = $page->exists();
-		$violation = $page->__get( Page_Table::VIOLATIONS );
-		$resolved = $page->__get( Page_Table::RESOLVED );
+		$latest_scan = Scan_Entry::get_scan_result( $url_trimmed, true );
+		$violation = $latest_scan['counts']['violation'];
+		$resolved = $latest_scan['counts']['issuesResolved'];
 
 		$passed = $has_scan_data && $resolved === $violation;
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix issue count discrepancy between WordPress admin and scanner by fetching latest scan results directly instead of relying on cached values.

Main changes:
- Updated scanner-wizard-context.js to use issuesResolved count directly from API response
- Added Scan_Entry integration in List_Column to get consistent violation and resolved counts
- Fixed resolved calculation logic to use actual issuesResolved value

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
