### PR TITLE
[APP-0000] Fix disable manage btn in dashboard, resolve issue with wp…

### DIFF
--- a/modules/remediation/components/cache-cleaner.php
+++ b/modules/remediation/components/cache-cleaner.php
@@ -14,6 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Cache_Cleaner {
 	const EA11Y_CLEAR_POST_CACHE_HOOK = 'ea11y_clear_post_cache';
 
+	public static function clean_ally_cache() : void {
+		Page_Entry::clear_all_cache();
+	}
+
 	public function add_litespeed_clean_hook() {
 		add_filter( 'litespeed_purge_post_events', function ( $events ) {
 			$events[] = self::EA11Y_CLEAR_POST_CACHE_HOOK;
@@ -56,6 +60,8 @@ class Cache_Cleaner {
 
 	public function __construct() {
 		$this->add_litespeed_clean_hook();
+		add_action( 'after_rocket_clean_domain', [ self::class, 'clean_ally_cache' ] );
+
 		add_action( 'created_term', [ $this, 'clean_taxonomy_cache' ], 10, 3 );
 		add_action( 'edited_term', [ $this, 'clean_taxonomy_cache' ], 10, 3 );
 		add_action( 'save_post', [ $this, 'clean_post_cache' ], 10, 3 );

--- a/modules/remediation/components/cache-cleaner.php
+++ b/modules/remediation/components/cache-cleaner.php
@@ -18,6 +18,32 @@ class Cache_Cleaner {
 		Page_Entry::clear_all_cache();
 	}
 
+	public static function clean_ally_post_cache( $post ) : void {
+		$url = get_permalink( $post->ID );
+		$url_trimmed = rtrim( $url, '/' );
+		Page_Entry::clear_cache( $url_trimmed );
+	}
+
+	public static function clean_ally_url_cache( $url ) : void {
+		$url_trimmed = rtrim( $url, '/' );
+		Page_Entry::clear_cache( $url_trimmed );
+	}
+
+	public static function clean_ally_list_cache( $urls ) : void {
+		foreach ( $urls as $url ) {
+			$url_trimmed = rtrim( $url, '/' );
+			Page_Entry::clear_cache( $url_trimmed );
+		}
+	}
+
+	public function add_wp_rocket_clean_action() {
+		add_action( 'rocket_after_clean_domain', [ self::class, 'clean_ally_cache' ] );
+		add_action( 'rocket_after_clean_terms', [ self::class, 'clean_ally_list_cache' ] );
+		add_action( 'after_rocket_clean_post', [ self::class, 'clean_ally_post_cache' ] );
+		add_action( 'after_rocket_clean_home', [ self::class, 'clean_ally_url_cache' ] );
+		add_action( 'after_rocket_clean_file', [ self::class, 'clean_ally_url_cache' ] );
+	}
+
 	public function add_litespeed_clean_hook() {
 		add_filter( 'litespeed_purge_post_events', function ( $events ) {
 			$events[] = self::EA11Y_CLEAR_POST_CACHE_HOOK;
@@ -60,7 +86,7 @@ class Cache_Cleaner {
 
 	public function __construct() {
 		$this->add_litespeed_clean_hook();
-		add_action( 'after_rocket_clean_domain', [ self::class, 'clean_ally_cache' ] );
+		$this->add_wp_rocket_clean_action();
 
 		add_action( 'created_term', [ $this, 'clean_taxonomy_cache' ], 10, 3 );
 		add_action( 'edited_term', [ $this, 'clean_taxonomy_cache' ], 10, 3 );

--- a/modules/remediation/components/cache-cleaner.php
+++ b/modules/remediation/components/cache-cleaner.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Cache_Cleaner
  */
 class Cache_Cleaner {
-	const EA11Y_CLEAR_POST_CACHE_HOOK = 'ea11y_clear_post_cache';
+	const EA11Y_CLEAR_POST_CACHE_HOOK = 'ea11y_run_clear_post_cache';
 
 	public static function clean_ally_cache() : void {
 		Page_Entry::clear_all_cache();

--- a/modules/remediation/components/cache-cleaner.php
+++ b/modules/remediation/components/cache-cleaner.php
@@ -12,24 +12,24 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class Cache_Cleaner
  */
 class Cache_Cleaner {
-	const EA11Y_CLEAR_POST_CACHE_HOOK = 'ea11y_run_clear_post_cache';
+	const EA11Y_CLEAR_POST_CACHE_HOOK = 'ea11y_clear_post_cache';
 
-	public static function clean_ally_cache() : void {
+	public static function clear_ally_cache() : void {
 		Page_Entry::clear_all_cache();
 	}
 
-	public static function clean_ally_post_cache( $post ) : void {
+	public static function clear_ally_post_cache( $post ) : void {
 		$url = get_permalink( $post->ID );
 		$url_trimmed = rtrim( $url, '/' );
 		Page_Entry::clear_cache( $url_trimmed );
 	}
 
-	public static function clean_ally_url_cache( $url ) : void {
+	public static function clear_ally_url_cache( $url ) : void {
 		$url_trimmed = rtrim( $url, '/' );
 		Page_Entry::clear_cache( $url_trimmed );
 	}
 
-	public static function clean_ally_list_cache( $urls ) : void {
+	public static function clear_ally_list_cache( $urls ) : void {
 		foreach ( $urls as $url ) {
 			$url_trimmed = rtrim( $url, '/' );
 			Page_Entry::clear_cache( $url_trimmed );
@@ -37,11 +37,11 @@ class Cache_Cleaner {
 	}
 
 	public function add_wp_rocket_clean_action() {
-		add_action( 'rocket_after_clean_domain', [ self::class, 'clean_ally_cache' ] );
-		add_action( 'rocket_after_clean_terms', [ self::class, 'clean_ally_list_cache' ] );
-		add_action( 'after_rocket_clean_post', [ self::class, 'clean_ally_post_cache' ] );
-		add_action( 'after_rocket_clean_home', [ self::class, 'clean_ally_url_cache' ] );
-		add_action( 'after_rocket_clean_file', [ self::class, 'clean_ally_url_cache' ] );
+		add_action( 'rocket_after_clean_domain', [ self::class, 'clear_ally_cache' ] );
+		add_action( 'rocket_after_clean_terms', [ self::class, 'clear_ally_list_cache' ] );
+		add_action( 'after_rocket_clean_post', [ self::class, 'clear_ally_post_cache' ] );
+		add_action( 'after_rocket_clean_home', [ self::class, 'clear_ally_url_cache' ] );
+		add_action( 'after_rocket_clean_file', [ self::class, 'clear_ally_url_cache' ] );
 	}
 
 	public function add_litespeed_clean_hook() {

--- a/modules/remediation/database/page-entry.php
+++ b/modules/remediation/database/page-entry.php
@@ -159,4 +159,9 @@ class Page_Entry extends Entry {
 			return;
 		}
 	}
+
+	public static function clear_all_cache() : void {
+		$query = 'UPDATE `' . Page_Table::table_name() . '` SET `' . Page_Table::FULL_HTML . '` = NULL WHERE `' . Page_Table::FULL_HTML . '` IS NOT NULL';
+		Page_Table::query( $query );
+	}
 }

--- a/modules/remediation/database/remediation-entry.php
+++ b/modules/remediation/database/remediation-entry.php
@@ -68,19 +68,7 @@ class Remediation_Entry extends Entry {
 	 * @return array
 	 */
 	public static function get_page_remediations( string $url, bool $total = false ) : array {
-		$where = $total ? [
-			[
-				'column' => Remediation_Table::table_name() . '.' . Remediation_Table::URL,
-				'value' => $url,
-				'operator' => '=',
-				'relation_after' => 'AND',
-			],
-			[
-				'column' => Remediation_Table::table_name() . '.' . Remediation_Table::GROUP,
-				'value' => 'altText',
-				'operator' => '<>',
-			],
-		] : [
+		$where = [
 			[
 				'column' => Remediation_Table::URL,
 				'value' => $url,


### PR DESCRIPTION
…-rocket cache
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix cache management for WordPress Rocket plugin and resolve dashboard button issue by implementing proper cache clearing integration.
Main changes:
- Added WP Rocket cache integration with custom hooks for domain, terms, post, home, and file cleaning
- Implemented method to clear all Ally cache entries in Page_Entry class
- Simplified URL cache clearing logic with consistent URL trimming across multiple functions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
