### PR TITLE
[APP-1865] fix clear cache button

### DIFF
--- a/modules/remediation/rest/clear-cache.php
+++ b/modules/remediation/rest/clear-cache.php
@@ -28,7 +28,7 @@ class Clear_Cache extends Route_Base {
 	 * @return WP_Error|WP_REST_Response
 	 *
 	 */
-	public function DELETE() {
+	public function DELETE( $request ) {
 		try {
 			$error = $this->verify_capability();
 
@@ -36,7 +36,12 @@ class Clear_Cache extends Route_Base {
 				return $error;
 			}
 
-			Cache_Cleaner::clear_ally_cache();
+			$url = esc_url( $request->get_param( 'url' ) );
+			if ( $url ) {
+				Cache_Cleaner::clear_ally_url_cache( $url );
+			} else {
+				Cache_Cleaner::clear_ally_cache();
+			}
 
 			return $this->respond_success_json( [
 				'message' => 'Cache cleared.',

--- a/modules/scanner/assets/js/api/APIScanner.js
+++ b/modules/scanner/assets/js/api/APIScanner.js
@@ -120,10 +120,11 @@ export class APIScanner extends API {
 		});
 	}
 
-	static async clearCache() {
+	static async clearCache(data) {
 		return APIScanner.request({
 			method: 'DELETE',
 			path: `${v1Prefix}/remediation/clear-cache`,
+			data,
 		});
 	}
 }

--- a/modules/scanner/assets/js/components/header/dropdown-menu.js
+++ b/modules/scanner/assets/js/components/header/dropdown-menu.js
@@ -49,7 +49,9 @@ export const DropdownMenu = () => {
 	const onClearCache = async () => {
 		try {
 			setLoading(true);
-			await APIScanner.clearCache();
+			await APIScanner.clearCache({
+				url: window.ea11yScannerData?.pageData?.url,
+			});
 			sendOnClickEvent('Clear cache');
 			handleClose();
 		} catch (e) {
@@ -104,18 +106,31 @@ export const DropdownMenu = () => {
 
 					<MenuItemText>{__('Rescan', 'pojo-accessibility')}</MenuItemText>
 				</MenuItem>
-				<MenuItem
-					onClick={onClearCache}
-					loading={loading}
-					disabled={loading}
-					dense
-				>
-					<MenuItemIcon>
-						<ClearIcon />
-					</MenuItemIcon>
+				{remediations.length > 0 ? (
+					<MenuItem
+						onClick={onClearCache}
+						loading={loading}
+						disabled={loading}
+						dense
+					>
+						<MenuItemIcon>
+							<ClearIcon />
+						</MenuItemIcon>
 
-					<MenuItemText>{__('Clear cache', 'pojo-accessibility')}</MenuItemText>
-				</MenuItem>
+						<MenuItemText>
+							{__('Clear cache', 'pojo-accessibility')}
+						</MenuItemText>
+					</MenuItem>
+				) : (
+					<MenuItem dense>
+						<MenuItemIcon>
+							<ClearIcon color="disabled" />
+						</MenuItemIcon>
+						<DisabledMenuItemText>
+							{__('Clear page cache', 'pojo-accessibility')}
+						</DisabledMenuItemText>
+					</MenuItem>
+				)}
 
 				{!remediations.length ? (
 					<Tooltip

--- a/modules/scanner/assets/js/constants/index.js
+++ b/modules/scanner/assets/js/constants/index.js
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 
 export const TOP_BAR_LINK = '#wp-admin-bar-ea11y-scanner-wizard a';
+export const SCAN_LINK = '#wp-admin-bar-ea11y-scan-page a';
 export const CLEAR_CACHE_LINK = '#wp-admin-bar-ea11y-clear-cache a';
 
 export const SCANNER_URL_PARAM = 'open-ea11y-assistant';

--- a/modules/scanner/assets/js/index.js
+++ b/modules/scanner/assets/js/index.js
@@ -12,6 +12,7 @@ import {
 	isRTL,
 	MANAGE_URL_PARAM,
 	ROOT_ID,
+	SCAN_LINK,
 	SCANNER_URL_PARAM,
 	TOP_BAR_LINK,
 } from '@ea11y-apps/scanner/constants';
@@ -34,20 +35,24 @@ document.addEventListener('DOMContentLoaded', function () {
 				console.error(e);
 			}
 		});
-	document.querySelector(TOP_BAR_LINK)?.addEventListener('click', (event) => {
-		event.preventDefault();
-		const rootNode = document.getElementById(ROOT_ID);
-		const url = new URL(window.location.href);
-		url.searchParams.delete('open-ea11y-assistant-src');
-		url.searchParams.append('open-ea11y-assistant-src', 'top_bar');
-		history.replaceState(null, '', url);
+	document
+		.querySelectorAll(`${TOP_BAR_LINK}, ${SCAN_LINK}`)
+		?.forEach((link) => {
+			link.addEventListener('click', (event) => {
+				event.preventDefault();
+				const rootNode = document.getElementById(ROOT_ID);
+				const url = new URL(window.location.href);
+				url.searchParams.delete('open-ea11y-assistant-src');
+				url.searchParams.append('open-ea11y-assistant-src', 'top_bar');
+				history.replaceState(null, '', url);
 
-		if (rootNode) {
-			closeWidget(rootNode);
-		} else {
-			initApp();
-		}
-	});
+				if (rootNode) {
+					closeWidget(rootNode);
+				} else {
+					initApp();
+				}
+			});
+		});
 	if (
 		params.get(SCANNER_URL_PARAM) === '1' ||
 		params.get(MANAGE_URL_PARAM) === '1'

--- a/modules/scanner/components/top-bar-link.php
+++ b/modules/scanner/components/top-bar-link.php
@@ -31,10 +31,17 @@ class Top_Bar_Link {
 				'title' => $svg_icon . esc_html__( 'Accessibility Assistant', 'pojo-accessibility' ),
 				'href' => '#', // Click event is handled by JS.
 			] );
-			// Add sub-item 1
+			// Add scan page
+			$wp_admin_bar->add_node( [
+				'id' => 'ea11y-scan-page',
+				'title'  => esc_html__( 'Scan page', 'pojo-accessibility' ),
+				'href' => '#', // Click event is handled by JS.
+				'parent' => 'ea11y-scanner-wizard',
+			] );
+			// Add clear all cache
 			$wp_admin_bar->add_node( [
 				'id' => 'ea11y-clear-cache',
-				'title'  => esc_html__( 'Clear cache', 'pojo-accessibility' ),
+				'title'  => esc_html__( 'Clear all cache', 'pojo-accessibility' ),
 				'href' => '#', // Click event is handled by JS.
 				'parent' => 'ea11y-scanner-wizard',
 			] );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix clear cache functionality by enabling per-URL cache clearing and disabling the button when no remediations exist.

Main changes:
- Added URL parameter to cache clearing API endpoint to enable page-specific cache clearing
- Disabled "Clear cache" button in dropdown menu when remediation list is empty
- Added new "Scan page" option in admin bar for improved navigation
- Updated cache clearing in PHP to handle both URL-specific and global cache clearing

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
