### PR TITLE
[APP-1956] apply only active remediations

### DIFF
--- a/modules/remediation/components/remediation-runner.php
+++ b/modules/remediation/components/remediation-runner.php
@@ -148,7 +148,7 @@ class Remediation_Runner {
 			]);
 
 			$this->page_html = $this->page->get_page_html();
-			$this->page_remediations = Remediation_Entry::get_page_remediations( $current_url );
+			$this->page_remediations = Remediation_Entry::get_page_active_remediations( $current_url );
 			$status = $this->page->__get( Page_Table::STATUS );
 
 			if ( empty( $this->page_remediations ) || Page_Table::STATUSES['ACTIVE'] !== $status ) {

--- a/modules/remediation/database/remediation-entry.php
+++ b/modules/remediation/database/remediation-entry.php
@@ -79,6 +79,30 @@ class Remediation_Entry extends Entry {
 		return Remediation_Table::select( $select, $where );
 	}
 
+	/**
+	 *  get_page_active_remediations
+	 *
+	 * @param string $url
+	 * @return array
+	 */
+	public static function get_page_active_remediations( string $url ) : array {
+		$where = [
+			[
+				'column' => Remediation_Table::URL,
+				'value' => $url,
+				'operator' => '=',
+				'relation_after' => 'AND',
+			],
+			[
+				'column' => Remediation_Table::ACTIVE,
+				'value' => 1,
+				'operator' => '=',
+			],
+		];
+
+		return Remediation_Table::select( '*', $where );
+	}
+
 	public static function get_all_remediations( int $period ) : array {
 		$date_threshold = gmdate( 'Y-m-d', strtotime( "-{$period} days" ) ) . ' 00:00:00';
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix remediation filtering to only apply active remediations to pages instead of applying all remediations regardless of status.

Main changes:
- Added new method get_page_active_remediations() that filters by active status 
- Updated remediation-runner.php to use the active-only remediation query
- Ensures disabled remediations won't be applied to pages

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
