### PR TITLE
[APP-1938] replace name with key for mixpanel

### DIFF
--- a/modules/scanner/assets/js/components/block-button/manage-button.js
+++ b/modules/scanner/assets/js/components/block-button/manage-button.js
@@ -22,7 +22,7 @@ export const ManageButton = ({ title, count, block }) => {
 		mixpanelService.sendEvent(mixpanelEvents.categoryClicked, {
 			page_url: window.ea11yScannerData?.pageData?.url,
 			issue_count: count,
-			category_name: title,
+			category_name: block,
 			source: 'remediation',
 		});
 	};

--- a/modules/settings/assets/js/components/sidebar-menu/menu-item.js
+++ b/modules/settings/assets/js/components/sidebar-menu/menu-item.js
@@ -37,7 +37,7 @@ const MenuItem = ({ keyName, item }) => {
 		window.location.hash = parentKey;
 
 		mixpanelService.sendEvent(mixpanelEvents.menuButtonClicked, {
-			buttonName: itemName,
+			buttonName: childKey || parentKey,
 		});
 	};
 
@@ -47,7 +47,7 @@ const MenuItem = ({ keyName, item }) => {
 			[itemKey]: !prev[itemKey], // Toggle the expanded state for the clicked item
 		}));
 		mixpanelService.sendEvent(mixpanelEvents.menuButtonClicked, {
-			buttonName: itemName,
+			buttonName: itemKey,
 		});
 	};
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update Mixpanel tracking parameters to use consistent key-based identifiers instead of display names for more reliable analytics.
Main changes:
- Changed category_name parameter from title to block in manage-button.js
- Updated buttonName parameter to use childKey/parentKey or itemKey instead of itemName in menu-item.js

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
