### PR TITLE
Added the Text Domain to a string in sitemap-settings/index.js

### DIFF
--- a/modules/settings/assets/js/components/sitemap-settings/index.js
+++ b/modules/settings/assets/js/components/sitemap-settings/index.js
@@ -66,7 +66,7 @@ const SitemapSettings = ({ sitemap }) => {
 			<StyledAccordionDetails>
 				<StyledBox>
 					<StyledFormLabel htmlFor="sitemap-url">
-						{__('Sitemap URL')}
+						{__('Sitemap URL', 'pojo-accessibility')}
 
 						<Infotip
 							content={


### PR DESCRIPTION
Added the Text Domain to a string in sitemap-settings/index.js
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add text domain to sitemap settings string to support localization and proper translation in the accessibility module.
Main changes:
- Added 'pojo-accessibility' text domain to 'Sitemap URL' string for proper translation support

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
