### PR TITLE
[APP-1903] hide skip link for "Hello elementor" theme

### DIFF
--- a/modules/core/components/skip-link.php
+++ b/modules/core/components/skip-link.php
@@ -71,6 +71,7 @@ class Skip_Link {
 
 		if ( $this->settings && ! empty( $this->settings['enabled'] ) ) {
 			remove_action( 'wp_footer', 'the_block_template_skip_link' );
+			add_filter( 'hello_elementor_enable_skip_link', '__return_false' );
 
 			add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_skip_link_styles' ] );
 			add_action( 'wp_body_open', [ $this, 'render_skip_link' ] );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add support for hiding skip links in the "Hello Elementor" theme when WP Accessibility skip link functionality is enabled.
Main changes:
- Added filter to disable Hello Elementor's native skip link when WP Accessibility skip link is enabled

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
