### PR TITLE
[APP-0000] remove upgrade link on one

### DIFF
--- a/modules/core/module.php
+++ b/modules/core/module.php
@@ -37,13 +37,14 @@ class Module extends Module_Base {
 			),
 		];
 
-		if ( Connect::is_connected() ) {
+		if ( Connect::is_connected() && ! Settings::is_elementor_one() ) {
 			$custom_links['upgrade'] = sprintf(
 				'<a href="%s" style="color: #524CFF; font-weight: 700;" target="_blank" rel="noopener noreferrer">%s</a>',
 				'https://go.elementor.com/ally-plugins-upgrade/',
 				esc_html__( 'Upgrade', 'pojo-accessibility' )
 			);
-		} else {
+		}
+		if ( ! Connect::is_connected() ) {
 			$custom_links['connect'] = sprintf(
 				'<a href="%s" style="color: #524CFF; font-weight: 700;">%s</a>',
 				admin_url( 'admin.php?page=' . Settings::SETTING_BASE_SLUG ),


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Hide upgrade link in plugin action links for Elementor One users while maintaining visibility for other connected users.

Main changes:
- Added conditional check to prevent upgrade link display when user is on Elementor One plan
- Refactored connection status logic into separate conditional blocks for upgrade and connect links
- Modified upgrade link visibility to require both connected status and non-Elementor-One plan

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
