### PR TITLE
[APP-0000] show mismatch modal independent on connection state

### DIFF
--- a/modules/settings/assets/js/app.js
+++ b/modules/settings/assets/js/app.js
@@ -78,7 +78,7 @@ const App = () => {
 						<ConnectModal />
 					)}
 					{isConnected && !closePostConnectModal && <PostConnectModal />}
-					{isUrlMismatch && isConnected && <UrlMismatchModal />}
+					{isUrlMismatch && <UrlMismatchModal />}
 					<OnboardingModal />
 					<GetStartedModal />
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix conditional logic for UrlMismatchModal display to show the modal independent of connection state, allowing users to address URL mismatches regardless of connectivity status.

Main changes:
- Removed `isConnected` condition from UrlMismatchModal rendering logic, enabling modal display whenever URL mismatch is detected
- Modal now displays unconditionally when `isUrlMismatch` is true, improving user experience for mismatch resolution scenarios

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
