### PR TITLE
[APP-0000] fix migration client id

### DIFF
--- a/classes/services/client.php
+++ b/classes/services/client.php
@@ -3,7 +3,6 @@
 namespace EA11y\Classes\Services;
 
 use EA11y\Modules\Connect\Module as Connect;
-use EA11y\Modules\Settings\Module as Settings_Module;
 use ElementorOne\Connect\Exceptions\Service_Exception;
 use Exception;
 use Throwable;
@@ -199,9 +198,7 @@ class Client {
 
 		// If there is mismatch then trigger the mismatch flow explicitly.
 		if ( ! $this->refreshed && ! empty( $body->message ) && ( false !== strpos( $body->message, 'site url mismatch' ) ) ) {
-			if ( ! Settings_Module::is_elementor_one() ) {
-				Connect::get_connect()->data()->set_home_url( 'https://wrongurl' );
-			}
+			Connect::get_connect()->data()->set_home_url( 'https://wrongurl' );
 			return new WP_Error( 401, 'site url mismatch' );
 		}
 

--- a/classes/services/client.php
+++ b/classes/services/client.php
@@ -3,6 +3,7 @@
 namespace EA11y\Classes\Services;
 
 use EA11y\Modules\Connect\Module as Connect;
+use EA11y\Modules\Settings\Module as Settings_Module;
 use ElementorOne\Connect\Exceptions\Service_Exception;
 use Exception;
 use Throwable;
@@ -198,7 +199,9 @@ class Client {
 
 		// If there is mismatch then trigger the mismatch flow explicitly.
 		if ( ! $this->refreshed && ! empty( $body->message ) && ( false !== strpos( $body->message, 'site url mismatch' ) ) ) {
-			Connect::get_connect()->data()->set_home_url( 'https://wrongurl' );
+			if ( ! Settings_Module::is_elementor_one() ) {
+				Connect::get_connect()->data()->set_home_url( 'https://wrongurl' );
+			}
 			return new WP_Error( 401, 'site url mismatch' );
 		}
 

--- a/modules/core/components/skip-link.php
+++ b/modules/core/components/skip-link.php
@@ -43,7 +43,7 @@ class Skip_Link {
 		<nav aria-label="<?php esc_attr_e( 'Skip to content navigation', 'pojo-accessibility' ); ?>">
 			<a class="ea11y-skip-to-content-link"
 				href="<?php echo esc_url( $this->settings['anchor'] ); ?>"
-				tabindex="1"
+				tabindex="-1"
 				onclick="onSkipLinkClick()"
 			>
 				<?php esc_attr_e( 'Skip to content', 'pojo-accessibility' ); ?>

--- a/modules/settings/classes/settings.php
+++ b/modules/settings/classes/settings.php
@@ -22,6 +22,7 @@ class Settings {
 	public const ANALYTICS_SETTINGS = 'ea11y_analytics_enabled';
 	public const PLAN_DATA_REFRESH_TRANSIENT = 'ea11y_plan_data_refresh';
 	public const SUBSCRIPTION_ID = 'ea11y_subscription_id';
+	public const CLIENT_ID = 'ea11y_client_id';
 
 	/**
 	 * Returns plugin settings data by option name

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -274,7 +274,24 @@ class Module extends Module_Base {
 					'site/migration',
 					[ 'old_client_id' => $client_id ],
 				);
+
 				self::save_plan_data( $migration_response );
+
+				$old_options = [
+					'ea11y_client_secret',
+					'ea11y_home_url',
+					'ea11y_access_token',
+					'ea11y_token_id',
+					'ea11y_refresh_token',
+					'ea11y_user_access_token',
+					'ea11y_owner_user_id',
+					Settings::SUBSCRIPTION_ID,
+					Settings::CLIENT_ID,
+				];
+
+				foreach ( $old_options as $option ) {
+					delete_option( $option );
+				}
 			} catch ( Throwable $t ) {
 				Logger::error( esc_html( $t->getMessage() ) );
 			}

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -265,7 +265,7 @@ class Module extends Module_Base {
 			return;
 		}
 
-		$client_id = Connect::get_connect()->data()->get_client_id();
+		$client_id = Settings::get( Settings::CLIENT_ID );
 
 		if ( $client_id ) {
 			try {

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -683,5 +683,8 @@ class Module extends Module_Base {
 		add_action( 'elementor_one/' . Config::APP_PREFIX . '_switched_domain', function( $facade ) {
 			$facade->service()->renew_access_token();
 		} );
+		add_action( 'elementor_one/switched_domain', function( $facade ) {
+			$facade->service()->renew_access_token();
+		} );
 	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix client ID retrieval in migration process by changing data source from Connect facade to Settings storage to ensure proper migration execution.

Main changes:
- Changed client ID retrieval from Connect::get_connect()->data()->get_client_id() to Settings::get(Settings::CLIENT_ID) in migration flow
- Added cleanup of 9 legacy authentication and configuration options after successful migration completion
- Added duplicate switched_domain action hook handler without APP_PREFIX for backward compatibility

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
