### PR TITLE
[APP-2380] Fix broken settings page in RTL websites

### DIFF
--- a/classes/utils.php
+++ b/classes/utils.php
@@ -15,7 +15,7 @@ class Utils {
 
 	public static function is_plugin_settings_page(): bool {
 		$current_screen = get_current_screen();
-		return str_contains( $current_screen->id, 'elementor_page_accessibility-settings' );
+		return str_contains( $current_screen->id, '_page_accessibility-settings' );
 	}
 
 	public static function is_elementor_installed() :bool {

--- a/modules/reviews/module.php
+++ b/modules/reviews/module.php
@@ -45,7 +45,7 @@ class Module extends Module_Base {
 	 * Enqueue Scripts and Styles
 	 */
 	public function enqueue_scripts( $hook ): void {
-		if ( SettingsModule::SETTING_PAGE_SLUG !== $hook ) {
+		if ( ! Utils::is_plugin_settings_page() ) {
 			return;
 		}
 

--- a/modules/reviews/module.php
+++ b/modules/reviews/module.php
@@ -44,7 +44,7 @@ class Module extends Module_Base {
 	/**
 	 * Enqueue Scripts and Styles
 	 */
-	public function enqueue_scripts( $hook ): void {
+	public function enqueue_scripts(): void {
 		if ( ! Utils::is_plugin_settings_page() ) {
 			return;
 		}

--- a/modules/settings/components/settings-pointer.php
+++ b/modules/settings/components/settings-pointer.php
@@ -26,9 +26,9 @@ class Settings_Pointer {
 			return;
 		}
 
-        if ( Utils::is_plugin_settings_page() ) {
-            return;
-        }
+		if ( Utils::is_plugin_settings_page() ) {
+			return;
+		}
 
 		wp_enqueue_script( 'wp-pointer' );
 		wp_enqueue_style( 'wp-pointer' );

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -73,7 +73,7 @@ class Module extends Module_Base {
 	/**
 	 * Enqueue Scripts and Styles
 	 */
-	public function enqueue_scripts( $hook ): void {
+	public function enqueue_scripts(): void {
 		if ( ! Utils::is_plugin_settings_page() ) {
 			return;
 		}

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -19,13 +19,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Module extends Module_Base {
-
-
 	const SETTING_PREFIX = 'ea11y_';
 	const SETTING_GROUP = 'ea11y_settings';
 	const SETTING_BASE_SLUG = 'accessibility-settings';
 	const SETTING_CAPABILITY = 'manage_options';
-	const SETTING_PAGE_SLUG = 'elementor_page_' . self::SETTING_BASE_SLUG;
 
 	public function get_name(): string {
 		return 'settings';
@@ -77,7 +74,7 @@ class Module extends Module_Base {
 	 * Enqueue Scripts and Styles
 	 */
 	public function enqueue_scripts( $hook ): void {
-		if ( self::SETTING_PAGE_SLUG !== $hook ) {
+		if ( ! Utils::is_plugin_settings_page() ) {
 			return;
 		}
 
@@ -117,7 +114,6 @@ class Module extends Module_Base {
 				'adminUrl' => admin_url(),
 				'isUrlMismatch' => ! Connect::get_connect()->utils()->is_valid_home_url(),
 				'isDevelopment' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
-
 				'homeUrl' => home_url(),
 			]
 		);
@@ -440,7 +436,7 @@ class Module extends Module_Base {
 	 * @return void
 	 */
 	public function check_plan_data( $current_screen ): void {
-		if ( self::SETTING_PAGE_SLUG !== $current_screen->base ) {
+		if ( ! str_contains( $current_screen->base, '_page_accessibility-settings' ) ) {
 			return;
 		}
 
@@ -456,9 +452,7 @@ class Module extends Module_Base {
 	}
 
 	public function remove_admin_footer_text( $text ) {
-		$screen = get_current_screen();
-
-		if ( self::SETTING_PAGE_SLUG === $screen->base ) {
+		if ( Utils::is_plugin_settings_page() ) {
 			remove_filter( 'update_footer', 'core_update_footer' );
 			return '';
 		}
@@ -664,8 +658,7 @@ class Module extends Module_Base {
 	 * Hide all admin notices on the settings page
 	 */
 	public function hide_admin_notices() {
-		$current_screen = get_current_screen();
-		if ( $current_screen && self::SETTING_PAGE_SLUG === $current_screen->id ) {
+		if ( Utils::is_plugin_settings_page() ) {
 			remove_all_actions( 'admin_notices' );
 			remove_all_actions( 'all_admin_notices' );
 		}

--- a/modules/widget/module.php
+++ b/modules/widget/module.php
@@ -7,6 +7,7 @@ use EA11y\Modules\Connect\Module as Connect;
 use EA11y\Modules\Settings\Module as SettingsModule;
 use EA11y\Modules\Analytics\Module as AnalyticsModule;
 use EA11y\Modules\Settings\Classes\Settings;
+use EA11y\Classes\Utils;
 use Exception;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -97,7 +98,7 @@ class Module extends Module_Base {
 	 * @return void
 	 */
 	public function enqueue_accessibility_widget_admin( $hook ) : void {
-		if ( SettingsModule::SETTING_PAGE_SLUG !== $hook ) {
+		if ( ! Utils::is_plugin_settings_page() ) {
 			return;
 		}
 

--- a/modules/widget/module.php
+++ b/modules/widget/module.php
@@ -93,11 +93,10 @@ class Module extends Module_Base {
 
 	/**
 	 * Load scripts in admin
-	 * @param $hook
 	 *
 	 * @return void
 	 */
-	public function enqueue_accessibility_widget_admin( $hook ) : void {
+	public function enqueue_accessibility_widget_admin() : void {
 		if ( ! Utils::is_plugin_settings_page() ) {
 			return;
 		}

--- a/pojo-accessibility.php
+++ b/pojo-accessibility.php
@@ -7,8 +7,8 @@
  * Author URI: https://elementor.com/
  * Version: 4.0.1
  * Text Domain: pojo-accessibility
- * Domain Path: /languages/
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 } // Exit if accessed directly


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix settings page detection logic to support RTL (right-to-left) language websites by using a more flexible page identification pattern.

Main changes:
- Replaced hardcoded 'elementor_page_accessibility-settings' string with flexible pattern matching using '_page_accessibility-settings' suffix
- Removed unused SETTING_PAGE_SLUG constant and simplified page detection across settings, reviews, and widget modules
- Refactored enqueue_scripts methods to use centralized Utils::is_plugin_settings_page() helper instead of hook parameter comparison

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
