### PR TITLE
[APP-2351] Allow users to disable the widget (not load the widget at all)

### DIFF
--- a/modules/settings/assets/js/components/bottom-bar/index.js
+++ b/modules/settings/assets/js/components/bottom-bar/index.js
@@ -11,6 +11,7 @@ const BottomBar = () => {
 		selectedMenu,
 		widgetMenuSettings,
 		skipToContentSettings,
+		widgetActivationSettings,
 		iconDesign,
 		iconPosition,
 		hasChanges,
@@ -27,6 +28,7 @@ const BottomBar = () => {
 			savedData = {
 				ea11y_widget_menu_settings: widgetMenuSettings,
 				ea11y_skip_to_content_settings: skipToContentSettings,
+				ea11y_widget_activation_settings: widgetActivationSettings,
 			};
 		} else if (selectedMenu.child === 'design') {
 			savedData = {

--- a/modules/settings/assets/js/components/index.js
+++ b/modules/settings/assets/js/components/index.js
@@ -18,6 +18,7 @@ export { default as StatementGenerator } from './statement-generator';
 export { default as AlertError } from './error';
 export { default as HtmlToTypography } from './html-to-typography';
 export { default as WidgetLoader } from './widget-loader';
+export { default as WidgetActivationSettings } from './widget-activation-settings';
 export { default as CopyLink } from './copy-link';
 export { default as EditLink } from './edit-link';
 export { default as GeneratedPageInfoTipCard } from './generated-page-infotip-card';

--- a/modules/settings/assets/js/components/widget-activation-settings/index.js
+++ b/modules/settings/assets/js/components/widget-activation-settings/index.js
@@ -51,7 +51,7 @@ const WidgetActivationSettings = () => {
 
 								<Typography variant="body2">
 									{__(
-										'Enable or disable the accessibility widget on your website.',
+										'Disabling it will prevent the widget from loading entirely.',
 										'pojo-accessibility',
 									)}
 								</Typography>
@@ -77,7 +77,7 @@ const WidgetActivationSettings = () => {
 
 			<Typography variant="body1">
 				{__(
-					'Disabling the widget will prevent the widget from loading entirely.',
+					'Enable or disable the accessibility widget on your website.',
 					'pojo-accessibility',
 				)}
 			</Typography>

--- a/modules/settings/assets/js/components/widget-activation-settings/index.js
+++ b/modules/settings/assets/js/components/widget-activation-settings/index.js
@@ -1,0 +1,113 @@
+import InfoCircleIcon from '@elementor/icons/InfoCircleIcon';
+import Box from '@elementor/ui/Box';
+import Card from '@elementor/ui/Card';
+import Infotip from '@elementor/ui/Infotip';
+import Switch from '@elementor/ui/Switch';
+import Typography from '@elementor/ui/Typography';
+import { styled } from '@elementor/ui/styles';
+import { useSettings } from '@ea11y/hooks';
+import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
+import { __ } from '@wordpress/i18n';
+
+const WidgetActivationSettings = () => {
+	const {
+		widgetActivationSettings,
+		setWidgetActivationSettings,
+		setHasChanges,
+	} = useSettings();
+
+	const toggleSetting = () => {
+		const newValue = !widgetActivationSettings.enabled;
+
+		setWidgetActivationSettings({
+			...widgetActivationSettings,
+			enabled: newValue,
+		});
+
+		setHasChanges(true);
+
+		mixpanelService.sendEvent(mixpanelEvents.toggleClicked, {
+			state: newValue ? 'on' : 'off',
+			type: 'Widget activation',
+		});
+	};
+
+	return (
+		<StyledCard variant="outlined">
+			<StyledBox>
+				<StyledTypography
+					variant="subtitle1"
+					id="ea11y-widget-activation-toggle"
+				>
+					{__('Widget Activation', 'pojo-accessibility')}
+
+					<Infotip
+						tabIndex="0"
+						content={
+							<Box sx={{ padding: 2, maxWidth: '250px' }}>
+								<Typography variant="subtitle2" sx={{ marginBlockEnd: 1 }}>
+									{__('Widget Activation', 'pojo-accessibility')}
+								</Typography>
+
+								<Typography variant="body2">
+									{__(
+										'Enable or disable the accessibility widget on your website.',
+										'pojo-accessibility',
+									)}
+								</Typography>
+							</Box>
+						}
+						placement="right"
+						arrow={true}
+					>
+						<InfoCircleIcon fontSize="small" />
+					</Infotip>
+				</StyledTypography>
+
+				<StyledSwitch
+					size="medium"
+					color="info"
+					checked={widgetActivationSettings.enabled ?? true}
+					onChange={toggleSetting}
+					inputProps={{
+						'aria-labelledby': 'ea11y-widget-activation-toggle',
+					}}
+				/>
+			</StyledBox>
+
+			<Typography variant="body1">
+				{__(
+					'Disabling the widget will prevent the widget from loading entirely.',
+					'pojo-accessibility',
+				)}
+			</Typography>
+		</StyledCard>
+	);
+};
+
+const StyledCard = styled(Card)`
+	padding: ${({ theme }) => theme.spacing(2)};
+	margin-block: ${({ theme }) => theme.spacing(4)};
+	margin-inline: auto;
+	max-width: 1200px;
+`;
+
+const StyledBox = styled(Box)`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+`;
+
+const StyledSwitch = styled(Switch)`
+	input {
+		height: 56px !important;
+	}
+`;
+
+const StyledTypography = styled(Typography)`
+	display: flex;
+	align-items: center;
+	gap: 8px;
+`;
+
+export default WidgetActivationSettings;

--- a/modules/settings/assets/js/hooks/use-saved-settings.js
+++ b/modules/settings/assets/js/hooks/use-saved-settings.js
@@ -18,6 +18,7 @@ export const useSavedSettings = () => {
 		setAccessibilityStatementData,
 		setShowAccessibilityGeneratedInfotip,
 		setSkipToContentSettings,
+		setWidgetActivationSettings,
 		setDismissedQuotaNotices,
 	} = useSettings();
 
@@ -92,6 +93,7 @@ export const useSavedSettings = () => {
 					result.data.ea11y_accessibility_statement_data,
 				);
 			}
+
 			if (result?.data?.ea11y_show_accessibility_generated_page_infotip) {
 				setShowAccessibilityGeneratedInfotip(
 					result.data.ea11y_show_accessibility_generated_page_infotip,
@@ -100,6 +102,12 @@ export const useSavedSettings = () => {
 
 			if (result?.data?.ea11y_skip_to_content_settings) {
 				setSkipToContentSettings(result?.data?.ea11y_skip_to_content_settings);
+			}
+
+			if (result?.data?.ea11y_widget_activation_settings) {
+				setWidgetActivationSettings(
+					result?.data?.ea11y_widget_activation_settings,
+				);
 			}
 
 			if (result?.data?.ea11y_analytics_enabled) {

--- a/modules/settings/assets/js/hooks/use-settings.js
+++ b/modules/settings/assets/js/hooks/use-settings.js
@@ -101,6 +101,10 @@ export const SettingsProvider = ({ children }) => {
 		enabled: true,
 	});
 
+	const [widgetActivationSettings, setWidgetActivationSettings] = useState({
+		enabled: true,
+	});
+
 	const [planData, setPlanData] = useState(null);
 
 	// Track settings changes to enable/disable Save Changes button
@@ -196,6 +200,8 @@ export const SettingsProvider = ({ children }) => {
 				setWidgetMenuSettings,
 				skipToContentSettings,
 				setSkipToContentSettings,
+				widgetActivationSettings,
+				setWidgetActivationSettings,
 				skipToContentHasChanges,
 				setSkipToContentHasChanges,
 				hideMinimumOptionAlert,

--- a/modules/settings/assets/js/pages/menu.js
+++ b/modules/settings/assets/js/pages/menu.js
@@ -1,6 +1,6 @@
 import Box from '@elementor/ui/Box';
 import { styled } from '@elementor/ui/styles';
-import { BottomBar } from '@ea11y/components';
+import { BottomBar, WidgetActivationSettings } from '@ea11y/components';
 import SkipToContentSettings from '@ea11y/components/skip-to-content-settings';
 import { MenuSettings, WidgetPreview } from '@ea11y/layouts';
 import {
@@ -32,6 +32,8 @@ const Menu = () => {
 				</StyledSettingsWrapper>
 
 				<SkipToContentSettings />
+
+				<WidgetActivationSettings />
 			</StyledWideBox>
 			<BottomBar />
 		</StyledBox>

--- a/modules/settings/classes/settings.php
+++ b/modules/settings/classes/settings.php
@@ -18,6 +18,7 @@ class Settings {
 	public const PLAN_SCOPE = 'ea11y_plan_scope';
 	public const WIDGET_ICON_SETTINGS = 'ea11y_widget_icon_settings';
 	public const WIDGET_MENU_SETTINGS = 'ea11y_widget_menu_settings';
+	public const WIDGET_ACTIVATION = 'ea11y_widget_activation_settings';
 	public const SKIP_TO_CONTENT = 'ea11y_skip_to_content_settings';
 	public const ANALYTICS_SETTINGS = 'ea11y_analytics_enabled';
 	public const PLAN_DATA_REFRESH_TRANSIENT = 'ea11y_plan_data_refresh';

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -149,6 +149,7 @@ class Module extends Module_Base {
 			'unfilteredUploads' => Svg::are_unfiltered_uploads_enabled(),
 			'homeUrl' => home_url(),
 			'isElementorOne' => self::is_elementor_one(),
+			'widgetActivationSettings' => Settings::get( Settings::WIDGET_ACTIVATION ),
 		];
 	}
 
@@ -398,6 +399,10 @@ class Module extends Module_Base {
 			'anchor' => '#content',
 		];
 
+		$widget_activation = [
+			'enabled' => true,
+		];
+
 		switch ( $setting ) {
 			case 'widget_menu_settings':
 				return $widget_menu_settings;
@@ -405,6 +410,8 @@ class Module extends Module_Base {
 				return $widget_icon_settings;
 			case 'skip_to_content_settings':
 				return $skip_to_content_setting;
+			case 'widget_activation_settings':
+				return $widget_activation;
 			default:
 				return [];
 		}
@@ -426,6 +433,10 @@ class Module extends Module_Base {
 
 		if ( ! get_option( Settings::SKIP_TO_CONTENT ) ) {
 			update_option( Settings::SKIP_TO_CONTENT, self::get_default_settings( 'skip_to_content_settings' ) );
+		}
+
+		if ( ! get_option( Settings::WIDGET_ACTIVATION ) ) {
+			update_option( Settings::WIDGET_ACTIVATION, self::get_default_settings( 'widget_activation' ) );
 		}
 	}
 
@@ -489,6 +500,15 @@ class Module extends Module_Base {
 				],
 			],
 			'skip_to_content_settings' => [
+				'type' => 'object',
+				'show_in_rest' => [
+					'schema' => [
+						'type' => 'object',
+						'additionalProperties' => true,
+					],
+				],
+			],
+			'widget_activation_settings' => [
 				'type' => 'object',
 				'show_in_rest' => [
 					'schema' => [

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -436,7 +436,7 @@ class Module extends Module_Base {
 		}
 
 		if ( ! get_option( Settings::WIDGET_ACTIVATION ) ) {
-			update_option( Settings::WIDGET_ACTIVATION, self::get_default_settings( 'widget_activation' ) );
+			update_option( Settings::WIDGET_ACTIVATION, self::get_default_settings( 'widget_activation_settings' ) );
 		}
 	}
 

--- a/modules/widget/module.php
+++ b/modules/widget/module.php
@@ -21,6 +21,34 @@ class Module extends Module_Base {
 	}
 
 	/**
+	 * Check if widget module is active
+	 *
+	 * @return bool
+	 */
+	public static function is_active(): bool {
+		// Check parent (legacy mode check)
+		if ( ! parent::is_active() ) {
+			return false;
+		}
+
+		// Check if widget is enabled in settings (default to `true` for backward compatibility)
+		$widget_activation = get_option( Settings::WIDGET_ACTIVATION, [ 'enabled' => true ] );
+
+		// Handle array format (expected)
+		if ( is_array( $widget_activation ) ) {
+			return isset( $widget_activation['enabled'] ) ? (bool) $widget_activation['enabled'] : true;
+		}
+
+		// Backward compatibility: if old boolean format exists
+		if ( is_bool( $widget_activation ) ) {
+			return $widget_activation;
+		}
+
+		// Default to enabled
+		return true;
+	}
+
+	/**
 	 * Enqueue scripts
 	 *
 	 * @return void


### PR DESCRIPTION

<img width="1920" height="958" alt="widget-activation" src="https://github.com/user-attachments/assets/ac0eb23b-db28-4b50-b01d-167b8ce7f4b3" />


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add widget activation toggle to allow users to completely disable the accessibility widget from loading on their website, preventing unnecessary resource consumption when the widget is not needed.

Main changes:
- Implemented WidgetActivationSettings component with toggle UI, info tooltip, and mixpanel tracking for widget enable/disable state
- Added widget activation state management across settings hooks, bottom bar save functionality, and REST API schema registration
- Modified widget module's is_active() method to check activation settings with backward compatibility for legacy boolean format

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
