### PR TITLE
[APP-2449] Don't hide admin notices

### DIFF
--- a/modules/settings/assets/css/style.css
+++ b/modules/settings/assets/css/style.css
@@ -17,15 +17,20 @@ body {
 }
 
 #ea11y-app {
-	position: relative;
+	position: fixed;
 	z-index: 1;
+	inset-block: 32px 0; /* 32px is for WP admin bar. */
+	inset-inline: 180px 0;
 	margin-inline-start: -20px;
 	background: #fff;
-	height: calc(100vh - 32px);
 }
 
 #ea11y-app * {
 	box-sizing: border-box;
+}
+
+#ea11y-app .wrap {
+	padding: 20px 40px 0;
 }
 
 .ea11y-textfield .MuiInputBase-input {

--- a/modules/settings/assets/css/style.css
+++ b/modules/settings/assets/css/style.css
@@ -25,6 +25,11 @@ body {
 	background: #fff;
 }
 
+body.folded #ea11y-app {
+	inset-inline-start: 36px;
+	margin-inline-start: 0;
+}
+
 #ea11y-app * {
 	box-sizing: border-box;
 }

--- a/modules/settings/assets/css/style.css
+++ b/modules/settings/assets/css/style.css
@@ -19,6 +19,7 @@ body {
 #ea11y-app {
 	position: fixed;
 	z-index: 1;
+	height: calc(100vh - 32px);
 	inset-block: 32px 0; /* 32px is for WP admin bar. */
 	inset-inline: 180px 0;
 	margin-inline-start: -20px;

--- a/modules/settings/assets/js/admin.js
+++ b/modules/settings/assets/js/admin.js
@@ -3,6 +3,7 @@ import { StrictMode, Fragment, createRoot } from '@wordpress/element';
 import App from './app';
 import { AnalyticsContextProvider } from './contexts/analytics-context';
 import { PluginSettingsProvider } from './contexts/plugin-settings';
+import { initNoticeRelocation } from './utils/move-notices';
 
 const rootNode = document.getElementById('ea11y-app');
 
@@ -10,18 +11,23 @@ const rootNode = document.getElementById('ea11y-app');
 const isDevelopment = window?.ea11ySettingsData?.isDevelopment;
 const AppWrapper = Boolean(isDevelopment) ? StrictMode : Fragment;
 
-const root = createRoot(rootNode);
+if (rootNode) {
+	const root = createRoot(rootNode);
 
-root.render(
-	<AppWrapper>
-		<NotificationsProvider>
-			<SettingsProvider>
-				<PluginSettingsProvider>
-					<AnalyticsContextProvider>
-						<App />
-					</AnalyticsContextProvider>
-				</PluginSettingsProvider>
-			</SettingsProvider>
-		</NotificationsProvider>
-	</AppWrapper>,
-);
+	root.render(
+		<AppWrapper>
+			<NotificationsProvider>
+				<SettingsProvider>
+					<PluginSettingsProvider>
+						<AnalyticsContextProvider>
+							<App />
+						</AnalyticsContextProvider>
+					</PluginSettingsProvider>
+				</SettingsProvider>
+			</NotificationsProvider>
+		</AppWrapper>,
+	);
+
+	// Move WordPress admin notices into the React app after rendering starts
+	initNoticeRelocation();
+}

--- a/modules/settings/assets/js/utils/move-notices.js
+++ b/modules/settings/assets/js/utils/move-notices.js
@@ -1,0 +1,120 @@
+const NOTICE_SELECTORS = '.wrap .notice, .wrap .updated, .wrap .error';
+const TARGET_SELECTOR = '#ea11y-app > div > div + div';
+const PLUGIN_SELECTOR = '#ea11y-app';
+const MAX_WAIT_ATTEMPTS = 10;
+const RETRY_INTERVAL = 100; // ms
+
+/**
+ * Move notices from WordPress admin to the React app container.
+ *
+ * @return {boolean} True if target exists and notices were processed, false otherwise.
+ */
+function moveNotices() {
+	const targetContainer = document.querySelector(TARGET_SELECTOR);
+
+	if (!targetContainer) {
+		return false;
+	}
+
+	// Find or create a .wrap element inside the target container
+	let wrapElement = targetContainer.querySelector('.wrap');
+	if (!wrapElement) {
+		wrapElement = document.createElement('div');
+		wrapElement.className = 'wrap';
+		targetContainer.prepend(wrapElement);
+	}
+
+	// Find all notices in .wrap containers
+	const notices = document.querySelectorAll(NOTICE_SELECTORS);
+
+	notices.forEach((notice) => {
+		// Only move notices that are NOT already inside the app
+		if (!notice.closest(PLUGIN_SELECTOR)) {
+			wrapElement.prepend(notice);
+		}
+	});
+
+	return true;
+}
+
+/**
+ * Set up a MutationObserver to watch for dynamically-added notices.
+ */
+function setupNoticeObserver() {
+	const observer = new MutationObserver((mutations) => {
+		mutations.forEach((mutation) => {
+			mutation.addedNodes.forEach((node) => {
+				// Check if the added node is a notice/error/updated element
+				if (
+					node.nodeType === Node.ELEMENT_NODE &&
+					(node.classList.contains('notice') ||
+						node.classList.contains('error') ||
+						node.classList.contains('updated'))
+				) {
+					// Check if it's in a .wrap but not in the app
+					const isInWrap = node.closest('.wrap');
+					const isInApp = node.closest(PLUGIN_SELECTOR);
+
+					if (isInWrap && !isInApp) {
+						const targetContainer = document.querySelector(TARGET_SELECTOR);
+						if (targetContainer) {
+							// Find or create a .wrap element inside the target container
+							let wrapElement = targetContainer.querySelector('.wrap');
+							if (!wrapElement) {
+								wrapElement = document.createElement('div');
+								wrapElement.className = 'wrap';
+								targetContainer.prepend(wrapElement);
+							}
+							wrapElement.prepend(node);
+						}
+					}
+				}
+			});
+		});
+	});
+
+	// Observe the entire document body for added notices
+	observer.observe(document.body, {
+		childList: true,
+		subtree: true,
+	});
+
+	return observer;
+}
+
+/**
+ * Wait for the React target element to exist, then move notices.
+ *
+ * This function polls for the target element with a retry mechanism,
+ * since React needs time to render the DOM structure.
+ */
+function waitAndMoveNotices() {
+	// Try moving immediately in case React has already rendered
+	if (moveNotices()) {
+		setupNoticeObserver();
+		return;
+	}
+
+	// Set up polling to wait for React to render
+	let attempts = 0;
+	const interval = setInterval(() => {
+		if (moveNotices() || attempts++ >= MAX_WAIT_ATTEMPTS) {
+			clearInterval(interval);
+
+			// Only set up observer if we successfully found the target
+			if (attempts < MAX_WAIT_ATTEMPTS) {
+				setupNoticeObserver();
+			}
+		}
+	}, RETRY_INTERVAL);
+}
+
+/**
+ * Initialize the notice relocation system.
+ *
+ * Call this function after React has started rendering to begin
+ * moving WordPress admin notices into the React app container.
+ */
+export function initNoticeRelocation() {
+	waitAndMoveNotices();
+}

--- a/modules/settings/banners/onboarding-banner.php
+++ b/modules/settings/banners/onboarding-banner.php
@@ -91,11 +91,6 @@ class Onboarding_Banner {
 		</div>
 
 		<style>
-			html[dir="rtl"] #ea11y-app,
-			html:not([dir="rtl"]) #ea11y-app {
-				height: calc(100vh - 32px - 80px);
-			}
-
 			.elementor-ea11y-banner {
 				overflow: hidden;
 				border-left-color: #2563EB;
@@ -177,7 +172,6 @@ class Onboarding_Banner {
 			document.addEventListener('DOMContentLoaded', function () {
 				const banner = document.querySelector('.elementor-ea11y-banner');
 				const button = document.querySelector('.elementor-ea11y-banner button');
-				const pageRoot = document.querySelector('#ea11y-app');
 
 				const requestData = {
 					action: "<?php echo esc_js( self::POINTER_ACTION ); ?>",
@@ -196,10 +190,6 @@ class Onboarding_Banner {
 								data: requestData,
 								success: () => {
 									banner.remove();
-
-									if (pageRoot) {
-										pageRoot.style.height = 'calc(100vh - 32px)';
-									}
 								},
 								error: (error) => console.error('Error:', error),
 							}

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -655,16 +655,6 @@ class Module extends Module_Base {
 	}
 
 	/**
-	 * Hide all admin notices on the settings page
-	 */
-	public function hide_admin_notices() {
-		if ( Utils::is_plugin_settings_page() ) {
-			remove_all_actions( 'admin_notices' );
-			remove_all_actions( 'all_admin_notices' );
-		}
-	}
-
-	/**
 	 * Module constructor.
 	 */
 	public function __construct() {
@@ -681,7 +671,6 @@ class Module extends Module_Base {
 		add_action( 'elementor_one/' . Config::APP_PREFIX . '_migration_run', [ $this, 'on_migration_run' ] );
 
 		add_action( 'current_screen', [ $this, 'check_plan_data' ] );
-		add_action( 'admin_head', [ $this, 'hide_admin_notices' ] );
 
 		// Register notices
 		add_action( 'ea11y_register_notices', [ $this, 'register_notices' ] );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove admin notice suppression and implement client-side notice relocation system to display WordPress admin notices within the React application container instead of hiding them.

Main changes:
- Added JavaScript utility to relocate WordPress admin notices into React app with MutationObserver for dynamic notices
- Removed hide_admin_notices() method and admin_head action hook that suppressed all WordPress admin notices
- Updated CSS positioning from relative to fixed layout with calculated viewport dimensions for proper notice display

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
