### PR TITLE
[APP-2467] Remove react jsx runtime polyfill

### DIFF
--- a/modules/scanner/module.php
+++ b/modules/scanner/module.php
@@ -58,16 +58,6 @@ class Module extends Module_Base {
 			return;
 		}
 
-		if ( version_compare( get_bloginfo( 'version' ), '6.6', '<' ) ) {
-			wp_register_script(
-				'react-jsx-runtime',
-				EA11Y_ASSETS_URL . 'lib/react-jsx-runtime.js',
-				[ 'react' ],
-				'18.3.0',
-				true
-			);
-		}
-
 		wp_enqueue_style(
 			'ea11y-scanner-wizard',
 			EA11Y_ASSETS_URL . 'build/ea11y-scanner-wizard.css',

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -80,16 +80,6 @@ class Module extends Module_Base {
 
 		wp_enqueue_media();
 
-		if ( version_compare( get_bloginfo( 'version' ), '6.6', '<' ) ) {
-			wp_register_script(
-				'react-jsx-runtime',
-				EA11Y_ASSETS_URL . 'lib/react-jsx-runtime.js',
-				[ 'react' ],
-				'18.3.0',
-				true
-			);
-		}
-
 		self::refresh_plan_data();
 
 		wp_enqueue_style(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,26 +40,6 @@ const entryPoints = {
 	),
 };
 
-// React JSX Runtime Polyfill
-const reactJSXRuntimePolyfill = {
-	entry: {
-		'react-jsx-runtime': {
-			import: 'react/jsx-runtime',
-		},
-	},
-	output: {
-		path: path.resolve(__dirname, 'assets/lib'),
-		filename: 'react-jsx-runtime.js',
-		library: {
-			name: 'ReactJSXRuntime',
-			type: 'window',
-		},
-	},
-	externals: {
-		react: 'React',
-	},
-};
-
 module.exports = [
 	{
 		...defaultConfig,
@@ -112,6 +92,4 @@ module.exports = [
 			],
 		},
 	},
-
-	reactJSXRuntimePolyfill,
 ];


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove React JSX Runtime polyfill that is now natively supported in WordPress 6.6+, eliminating unnecessary build complexity and conditional script loading.

Main changes:
- Removed reactJSXRuntimePolyfill webpack configuration and its export from module.exports array
- Deleted conditional React JSX Runtime script registration in Scanner and Settings modules for WordPress versions below 6.6
- Simplified asset enqueueing by eliminating version checks and manual polyfill script registration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
