### PR TITLE
[APP-2469] Remove duplicate font files to reduce plugin size

### DIFF
--- a/modules/core/module.php
+++ b/modules/core/module.php
@@ -61,7 +61,7 @@ class Module extends Module_Base {
 
 	public function enqueue_scripts() : void {
 		wp_enqueue_style(
-			'ea11y-global-style',
+			'ea11y-global-admin-style',
 			EA11Y_ASSETS_URL . 'css/admin.css',
 			[],
 			EA11Y_VERSION

--- a/modules/widget/module.php
+++ b/modules/widget/module.php
@@ -75,7 +75,7 @@ class Module extends Module_Base {
 
 		wp_enqueue_style(
 			'ea11y-widget-fonts',
-			EA11Y_ASSETS_URL . 'build/fonts.css',
+			EA11Y_ASSETS_URL . 'css/fonts.css',
 			[],
 			EA11Y_VERSION
 		);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,6 @@ const entryPoints = {
 		'assets/dev/css',
 		'ea11y-scanner-admin.scss',
 	),
-	fonts: path.resolve(process.cwd(), 'assets/css', 'fonts.css'),
 	'skip-link': path.resolve(process.cwd(), 'assets/dev/css', 'skip-link.scss'),
 	'gutenberg-custom-link': path.resolve(
 		process.cwd(),


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Optimize plugin build size by excluding font files from webpack bundling and moving them to direct CSS references in production assets.

Main changes:
- Removed fonts entry point from webpack configuration to prevent bundling font files into build output
- Updated widget module to load fonts.css directly from assets/css instead of webpack build directory
- Renamed global admin style handle from 'ea11y-global-style' to 'ea11y-global-admin-style' for better clarity

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
