### PR TITLE
Update elementor/wp-one-package to 1.0.54

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 		"elementor/wp-notifications-package": "^1.2.0",
 		"ext-ctype": "*",
 		"ext-mbstring": "*",
-		"elementor/wp-one-package": "1.0.50"
+		"elementor/wp-one-package": "1.0.54"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update elementor/wp-one-package dependency from version 1.0.50 to 1.0.54 to incorporate latest bug fixes and improvements.
Main changes:
- Upgraded elementor/wp-one-package dependency version from 1.0.50 to 1.0.54 in composer.json

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
