### PR TITLE
[APP-2511] Add preparing for SQL request, fix url sql injection, remove pkg with security issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
 		"lint:report": "vendor/bin/phpcs --report=summary --standard=./ruleset.xml ./**/*.php"
 	},
 	"require": {
-		"firebase/php-jwt": "^6.10",
 		"ext-json": "*",
 		"ext-fileinfo": "*",
 		"ext-curl": "*",

--- a/modules/remediation/database/remediation-entry.php
+++ b/modules/remediation/database/remediation-entry.php
@@ -212,7 +212,11 @@ class Remediation_Entry extends Entry {
 				'operator' => '=',
 			],
 		];
-		$join = "LEFT JOIN $excluded_table ON $remediation_table.id = $excluded_table.remediation_id AND $excluded_table.page_url = '$url'";
+		// Use prepare() to safely bind the URL; never concatenate user input into SQL.
+		$join = Remediation_Table::db()->prepare(
+			"LEFT JOIN $excluded_table ON $remediation_table.id = $excluded_table.remediation_id AND $excluded_table.page_url = %s",
+			$url
+		);
 		return Remediation_Table::select( "$remediation_table.*, COALESCE($excluded_table.active, $remediation_table.active) AS active_for_page", $global_where, null, null, $join );
 	}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix SQL injection vulnerability in remediation entry retrieval by implementing prepared statements for URL parameter binding in database queries.

Main changes:
- Replaced direct string concatenation of $url parameter with WordPress prepare() method to prevent SQL injection attacks
- Added prepared statement for LEFT JOIN clause binding page_url parameter safely
- Removed unsafe inline URL interpolation in SQL query construction

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
