### PR TITLE
Fix: Use site_url() instead of home_url() for Bedrock compatibility

### DIFF
--- a/classes/services/client.php
+++ b/classes/services/client.php
@@ -51,7 +51,7 @@ class Client {
 			// Which language to return.
 			'site_lang' => get_bloginfo( 'language' ),
 			// site to connect
-			'site_url' => trailingslashit( home_url() ),
+			'site_url' => trailingslashit( site_url() ),
 			// current user
 			'local_id' => get_current_user_id(),
 			// User Agent


### PR DESCRIPTION
On Bedrock installations, home_url() and site_url() differ. The OAuth token contains site_url(), but the plugin was sending home_url(), causing 'site url mismatch' error.

Fixes #529 
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix site URL detection in API client to ensure compatibility with Bedrock WordPress installations where site and home URLs differ.

Main changes:
- Replace home_url() with site_url() in Client class to correctly identify WordPress installation directory
- Ensure API client sends accurate site URL for Bedrock multisite and custom directory configurations

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
