### PR TITLE
[APP-2532] Improve admin notice accessibility

### DIFF
--- a/classes/utils/notice-base.php
+++ b/classes/utils/notice-base.php
@@ -157,8 +157,7 @@ class Notice_Base {
 	}
 
 	public function render() {
-		echo sprintf(
-			'<div class="notice_wrapper notice %1$s notice-%2$s %2$s %3$s" data-notice-id="%3$s" data-notice-action="%4$s" data-notice-nonce="%5$s" role="region" aria-label="%6$s">%7$s</div>',
+		echo sprintf( '<div class="notice_wrapper notice %1$s notice-%2$s %2$s %3$s" data-notice-id="%3$s" data-notice-action="%4$s" data-notice-nonce="%5$s" role="region" aria-label="%6$s">%7$s</div>',
 			$this->is_dismissible ? 'ea11y-dismiss is-dismissible' : '',
 			esc_attr( $this->type ),
 			esc_attr( $this->get_id() ),

--- a/classes/utils/notice-base.php
+++ b/classes/utils/notice-base.php
@@ -157,13 +157,13 @@ class Notice_Base {
 	}
 
 	public function render() {
-		echo sprintf( '<div class="notice_wrapper notice %1$s notice-%2$s %2$s %3$s" data-notice-id="%3$s" data-notice-action="%4$s" data-notice-nonce="%5$s" role="region" aria-label="%6$s">%7$s</div>',
+		echo sprintf( '<div role="region" aria-label="%1$s" class="notice_wrapper notice %2$s notice-%3$s %3$s %4$s" data-notice-id="%4$s" data-notice-action="%5$s" data-notice-nonce="%6$s">%7$s</div>',
+			esc_attr__( 'Notice', 'pojo-accessibility' ),
 			$this->is_dismissible ? 'ea11y-dismiss is-dismissible' : '',
 			esc_attr( $this->type ),
 			esc_attr( $this->get_id() ),
 			esc_attr( $this->get_action_name() ),
 			wp_create_nonce( $this->get_action_name() ),
-			esc_attr__( 'Notice', 'pojo-accessibility' ),
 			$this->content()
 		);
 	}

--- a/classes/utils/notice-base.php
+++ b/classes/utils/notice-base.php
@@ -163,6 +163,7 @@ class Notice_Base {
 			esc_attr( $this->type ),
 			esc_attr( $this->get_id() ),
 			esc_attr( $this->get_action_name() ),
+			wp_create_nonce( $this->get_action_name() ),
 			esc_attr__( 'Notice', 'pojo-accessibility' ),
 			$this->content()
 		);

--- a/classes/utils/notice-base.php
+++ b/classes/utils/notice-base.php
@@ -157,12 +157,13 @@ class Notice_Base {
 	}
 
 	public function render() {
-		echo sprintf( '<div class="notice_wrapper notice %1$s notice-%2$s %2$s %3$s" data-notice-id="%3$s" data-notice-action="%4$s" data-notice-nonce="%5$s">%6$s</div>',
+		echo sprintf(
+			'<div class="notice_wrapper notice %1$s notice-%2$s %2$s %3$s" data-notice-id="%3$s" data-notice-action="%4$s" data-notice-nonce="%5$s" role="region" aria-label="%6$s">%7$s</div>',
 			$this->is_dismissible ? 'ea11y-dismiss is-dismissible' : '',
 			esc_attr( $this->type ),
 			esc_attr( $this->get_id() ),
 			esc_attr( $this->get_action_name() ),
-			wp_create_nonce( $this->get_action_name() ),
+			esc_attr__( 'Notice', 'pojo-accessibility' ),
 			$this->content()
 		);
 	}


### PR DESCRIPTION
Add `role="region" aria-label="Notice"` to Ally notices.


<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add ARIA attributes to admin notice wrapper to improve screen reader accessibility and compliance with WCAG standards.

Main changes:
- Added role="region" and aria-label="Notice" attributes to notice wrapper div for better assistive technology support
- Reordered sprintf parameters to accommodate new accessibility attributes while maintaining existing functionality
- Introduced localized aria-label using esc_attr__() for internationalization support

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
