### PR TITLE
[APP-2532] Improve admin notice accessibility

### DIFF
--- a/modules/legacy/components/admin.php
+++ b/modules/legacy/components/admin.php
@@ -113,7 +113,7 @@ class Admin {
 				}
 			}
 		</style>
-		<div class="notice updated is-dismissible a11y-notice a11y-install-elementor">
+		<div role="region" aria-label="<?php esc_attr_e( 'Notice', 'pojo-accessibility' ); ?>" class="notice updated is-dismissible a11y-notice a11y-install-elementor">
 			<div class="a11y-notice-inner">
 				<div class="a11y-notice-icon">
 					<svg width="50" height="50" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/modules/settings/notices/renewal-notice.php
+++ b/modules/settings/notices/renewal-notice.php
@@ -122,7 +122,7 @@ class Renewal_Notice extends Notice_Base {
 		$this->type = $text['type'];
 		$icon = $this->get_notice_icon( $text['type'] );
 		return sprintf(
-			'<div class="ea11y__notice-icon">%s</div><div class="ea11y__notice-content"><b>%s</b><span>%s</span><a class="ea11y__renewal-notice-btn" href="%s" target="_blank" rel="noopener noreferrer">%s</a></div>',
+			'<div class="ea11y__notice-icon" aria-hidden="true">%s</div><div class="ea11y__notice-content"><b>%s</b><span>%s</span><a class="ea11y__renewal-notice-btn" href="%s" target="_blank" rel="noopener noreferrer">%s</a></div>',
 			$icon,
 			$text['title'],
 			$text['description'],
@@ -138,7 +138,8 @@ class Renewal_Notice extends Notice_Base {
 		$text = ( null !== $this->days_diff ) ? $this->get_renewal_text() : [ 'type' => $this->type ];
 		$type_attr = isset( $text['type'] ) ? $text['type'] : $this->type;
 		printf(
-			'<div class="notice notice-info ea11y-dismiss is-dismissible ea11y__notice ea11y__notice--%1$s ea11y__renewal-notice" data-notice-id="%2$s" data-notice-action="%3$s" data-notice-nonce="%4$s"><div class="ea11y__content-block">%5$s</div></div>',
+			'<div role="region" aria-label="%1$s" class="notice notice-info ea11y-dismiss is-dismissible ea11y__notice ea11y__notice--%2$s ea11y__renewal-notice" data-notice-id="%3$s" data-notice-action="%4$s" data-notice-nonce="%5$s"><div class="ea11y__content-block">%6$s</div></div>',
+			esc_attr__( 'Notice', 'pojo-accessibility' ),
 			esc_attr( $type_attr ),
 			esc_attr( $this->get_id() ),
 			esc_attr( $this->get_action_name() ),


### PR DESCRIPTION
Related to #534

Add `role="region" aria-label="Notice"` to Ally notices.



<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enhance accessibility of admin notice components by adding ARIA attributes and semantic HTML roles for screen reader compatibility.

Main changes:
- Added role="region" and aria-label="Notice" attributes to admin notice div elements for proper ARIA landmark identification
- Added aria-hidden="true" to decorative notice icon wrapper to prevent screen readers from announcing non-essential visual elements
- Updated renewal notice sprintf template parameters to accommodate new accessibility attributes in rendered HTML output

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
