### PR TITLE
[APP-2533] Add renewal banner for Ally

### DIFF
--- a/modules/settings/notices/renewal-notice.php
+++ b/modules/settings/notices/renewal-notice.php
@@ -82,7 +82,7 @@ class Renewal_Notice extends Notice_Base {
 	}
 
 	public function get_renewal_text(): array {
-		if ( 1 === 1 ) {
+		if ( $this->days_diff <= 30 && $this->days_diff > 0 ) {
 			return [
 				'title'       => esc_html__( 'Ally Subscription Ending Soon!', 'pojo-accessibility' ),
 				'description' => esc_html__( 'Renew now to keep access to Ally Assistant and continue improving your website\'s accessibility with guided fixes and scans.', 'pojo-accessibility' ),

--- a/modules/settings/notices/renewal-notice.php
+++ b/modules/settings/notices/renewal-notice.php
@@ -19,8 +19,6 @@ class Renewal_Notice extends Notice_Base {
 
 	const DISMISSED_AT_USER_META = 'ea11y_renewal_notice_dismissed_at';
 
-	const MS_IN_ONE_DAY = 86400000;
-
 	/**
 	 * @var bool
 	 */
@@ -84,7 +82,7 @@ class Renewal_Notice extends Notice_Base {
 	}
 
 	public function get_renewal_text(): array {
-		if ( $this->days_diff <= 30 && $this->days_diff > 0 ) {
+		if ( 1 === 1 ) {
 			return [
 				'title'       => esc_html__( 'Ally Subscription Ending Soon!', 'pojo-accessibility' ),
 				'description' => esc_html__( 'Renew now to keep access to Ally Assistant and continue improving your website\'s accessibility with guided fixes and scans.', 'pojo-accessibility' ),
@@ -157,7 +155,7 @@ class Renewal_Notice extends Notice_Base {
 		if ( ! $dismissed_at || ! is_numeric( $dismissed_at ) ) {
 			return false;
 		}
-		return ( time() * 1000 - (int) $dismissed_at ) < self::MS_IN_ONE_DAY;
+		return ( time() - (int) $dismissed_at ) < DAY_IN_SECONDS;
 	}
 
 	public function dismiss_per_user(): void {
@@ -165,7 +163,7 @@ class Renewal_Notice extends Notice_Base {
 		if ( ! $user_id ) {
 			wp_send_json_error( [ 'message' => 'Invalid user' ] );
 		}
-		update_user_meta( $user_id, self::DISMISSED_AT_USER_META, (string) ( time() * 1000 ) );
+		update_user_meta( $user_id, self::DISMISSED_AT_USER_META, (string) time() );
 	}
 
 	public function maybe_set_conditions() {


### PR DESCRIPTION
Related: #531

Replace custom `MS_IN_ONE_DAY` with WordPress `DAY_IN_SECONDS` constant.



<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix timestamp unit inconsistency in renewal notice dismissal logic by converting from milliseconds to seconds-based tracking.

Main changes:
- Removed MS_IN_ONE_DAY constant and replaced millisecond calculations with WordPress DAY_IN_SECONDS constant
- Updated dismiss_per_user() to store Unix timestamp in seconds instead of milliseconds
- Modified is_dismissed_for_today() comparison logic to use seconds-based time calculation for consistency

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
