### PR TITLE
Update packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,5 @@
 {
-	"name": "pojome/pojo-accessibility",
-	"description": "pojo accessibility",
-	"license": "gpl2",
-	"author": "Elementor",
+	"name": "pojo-accessibility",
 	"require-dev": {
 		"johnpbloch/wordpress-core": "^6.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,8 @@
 {
 	"name": "pojome/pojo-accessibility",
 	"description": "pojo accessibility",
-	"minimum-stability": "dev",
 	"license": "gpl2",
-	"authors": [
-		{
-			"name": "Yakir Sitbon",
-			"email": "yakir@pojo.me"
-		}
-	],
+	"author": "Elementor",
 	"require-dev": {
 		"johnpbloch/wordpress-core": "^6.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
@@ -38,7 +32,7 @@
 		"ext-ctype": "*",
 		"ext-mbstring": "*",
 		"elementor/wp-notifications-package": "^1.2.0",
-		"elementor/wp-one-package": "1.0.54"
+		"elementor/wp-one-package": "1.0.59"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "pojo-accessibility",
+	"name": "elementor/pojo-accessibility",
 	"require-dev": {
 		"johnpbloch/wordpress-core": "^6.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.1.0",
 			"dependencies": {
 				"@elementor/design-tokens": "^1.1.4",
-				"@elementor/elementor-one-assets": "0.4.24",
+				"@elementor/elementor-one-assets": "0.4.32",
 				"@elementor/icons": "^1.65.0",
 				"@elementor/ui": "^1.37.3",
 				"@emotion/cache": "^11.14.0",
@@ -2206,9 +2206,9 @@
 			"license": "GPL-3.0-or-later"
 		},
 		"node_modules/@elementor/elementor-one-assets": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.24.tgz",
-			"integrity": "sha512-bUKCt23db2SPgZEDGWosiXVsJVSGZ6ZzGhtDzRthyi8yYZhr0MOrXACZ5OJt4INdSohWWpTypWKxsaK3EE9T2g==",
+			"version": "0.4.32",
+			"resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.32.tgz",
+			"integrity": "sha512-SP1RIK0cGlgYCICh3UGXivVFe8lZg7TscLdHHLA4kVr/AKc5/FqFX1E6UCfa27YoL6bC6Qw/lvzu1+txWRBvGA==",
 			"dependencies": {
 				"@elementor/icons": "^1.60.0",
 				"@elementor/ui": "1.37.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,5 @@
 {
 	"name": "pojo-accessibility",
-	"slug": "pojo-accessibility",
-	"homepage": "http://pojo.me/",
 	"description": "",
 	"version": "4.1.0",
 	"scripts": {
@@ -47,7 +45,7 @@
 	},
 	"dependencies": {
 		"@elementor/design-tokens": "^1.1.4",
-		"@elementor/elementor-one-assets": "0.4.24",
+		"@elementor/elementor-one-assets": "0.4.32",
 		"@elementor/icons": "^1.65.0",
 		"@elementor/ui": "^1.37.3",
 		"@emotion/cache": "^11.14.0",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update package dependencies and rebrand project ownership from pojome to elementor organization in composer and npm configurations.

Main changes:
- Updated composer.json package name from pojome/pojo-accessibility to elementor/pojo-accessibility and removed deprecated metadata fields
- Upgraded elementor/wp-one-package dependency from version 1.0.54 to 1.0.59 in composer requirements
- Upgraded @elementor/elementor-one-assets from version 0.4.24 to 0.4.32 and removed unused npm metadata fields

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
