### PR TITLE
[APP-2757] Ally - wp plugin

### DIFF
--- a/classes/services/client.php
+++ b/classes/services/client.php
@@ -52,6 +52,8 @@ class Client {
 			'site_lang' => get_bloginfo( 'language' ),
 			// site to connect
 			'site_url' => trailingslashit( home_url() ),
+			// Alt site url
+			'alt_site_url' => trailingslashit( site_url() ),
 			// current user
 			'local_id' => get_current_user_id(),
 			// User Agent


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding alternate site URL to API client payload for improved site connectivity resolution when primary `home_url()` differs from `site_url()` (APP-2757).

## 2. What Changed (Where)

`classes/services/client.php`: Added `alt_site_url` parameter to API request headers using `site_url()` as fallback.

## 3. How It Works

API client now sends both `site_url` (primary) and `alt_site_url` (fallback) in request headers, allowing server-side logic to handle multisite/subdirectory WordPress setups that may have mismatched URLs.

## 4. Risks

Minimal—read-only parameter addition. Verify server-side consumer handles missing `alt_site_url` gracefully for backward compatibility.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
