### PR TITLE
[APP-2867] Update elementor/wp-one-package to 1.0.62

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"ext-ctype": "*",
 		"ext-mbstring": "*",
 		"elementor/wp-notifications-package": "^1.2.0",
-		"elementor/wp-one-package": "1.0.59"
+		"elementor/wp-one-package": "1.0.62"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Dependency patch for elementor/wp-one-package addressing APP-2867. Version bump from 1.0.59 to 1.0.62.

## 2. What Changed (Where)

- composer.json: Updated elementor/wp-one-package constraint from 1.0.59 to 1.0.62 (pinned version).

## 3. How It Works

Composer will lock the exact version 1.0.62 on next install/update—no pre-release or patch flexibility.

## 4. Risks

Version pinning removes automatic patch-level updates; verify 1.0.62 changelog for breaking changes vs 1.0.59.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
