### PR TITLE
[APP-2867] Update Elementor One Assets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"ext-ctype": "*",
 		"ext-mbstring": "*",
 		"elementor/wp-notifications-package": "^1.2.0",
-		"elementor/wp-one-package": "1.0.59"
+		"elementor/wp-one-package": "1.0.62"
 	},
 	"config": {
 		"allow-plugins": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.1.1",
 			"dependencies": {
 				"@elementor/design-tokens": "^1.1.4",
-				"@elementor/elementor-one-assets": "0.4.32",
+				"@elementor/elementor-one-assets": "0.4.35",
 				"@elementor/icons": "^1.65.0",
 				"@elementor/ui": "^1.37.3",
 				"@emotion/cache": "^11.14.0",
@@ -2206,9 +2206,10 @@
 			"license": "GPL-3.0-or-later"
 		},
 		"node_modules/@elementor/elementor-one-assets": {
-			"version": "0.4.32",
-			"resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.32.tgz",
-			"integrity": "sha512-SP1RIK0cGlgYCICh3UGXivVFe8lZg7TscLdHHLA4kVr/AKc5/FqFX1E6UCfa27YoL6bC6Qw/lvzu1+txWRBvGA==",
+			"version": "0.4.35",
+			"resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.35.tgz",
+			"integrity": "sha512-z5EZIPedcicUFVqQs8NNAyBDrh/sCn0czsqYr/plrNpdrVKQdnuMeVJvp7ZlbfbcErYZvEZLREWwnNivF2/PyA==",
+			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@elementor/icons": "^1.60.0",
 				"@elementor/ui": "1.37.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 	},
 	"dependencies": {
 		"@elementor/design-tokens": "^1.1.4",
-		"@elementor/elementor-one-assets": "0.4.32",
+		"@elementor/elementor-one-assets": "0.4.35",
 		"@elementor/icons": "^1.65.0",
 		"@elementor/ui": "^1.37.3",
 		"@emotion/cache": "^11.14.0",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Updating Elementor One package and assets to latest stable versions (APP-2867). Patch bumps to resolve dependencies and ensure compatibility.

## 2. What Changed (Where)

- `composer.json`: `elementor/wp-one-package` 1.0.59 → 1.0.62
- `package.json`: `@elementor/elementor-one-assets` 0.4.32 → 0.4.35

## 3. How It Works

Straightforward dependency version updates in lock files. No logic changes—Composer and npm will pull specified package versions on next install.

## 4. Risks

Minimal. Patch-level bumps are low-risk. Verify no breaking changes in one-package 1.0.62 and elementor-one-assets 0.4.35 release notes if available.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
