### PR TITLE
[APP-2867] Update Elementor One Assets package to 0.4.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "4.1.1",
 			"dependencies": {
 				"@elementor/design-tokens": "^1.1.4",
-				"@elementor/elementor-one-assets": "0.4.32",
+				"@elementor/elementor-one-assets": "0.4.35",
 				"@elementor/icons": "^1.65.0",
 				"@elementor/ui": "^1.37.3",
 				"@emotion/cache": "^11.14.0",
@@ -2206,9 +2206,10 @@
 			"license": "GPL-3.0-or-later"
 		},
 		"node_modules/@elementor/elementor-one-assets": {
-			"version": "0.4.32",
-			"resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.32.tgz",
-			"integrity": "sha512-SP1RIK0cGlgYCICh3UGXivVFe8lZg7TscLdHHLA4kVr/AKc5/FqFX1E6UCfa27YoL6bC6Qw/lvzu1+txWRBvGA==",
+			"version": "0.4.35",
+			"resolved": "https://registry.npmjs.org/@elementor/elementor-one-assets/-/elementor-one-assets-0.4.35.tgz",
+			"integrity": "sha512-z5EZIPedcicUFVqQs8NNAyBDrh/sCn0czsqYr/plrNpdrVKQdnuMeVJvp7ZlbfbcErYZvEZLREWwnNivF2/PyA==",
+			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@elementor/icons": "^1.60.0",
 				"@elementor/ui": "1.37.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 	},
 	"dependencies": {
 		"@elementor/design-tokens": "^1.1.4",
-		"@elementor/elementor-one-assets": "0.4.32",
+		"@elementor/elementor-one-assets": "0.4.35",
 		"@elementor/icons": "^1.65.0",
 		"@elementor/ui": "^1.37.3",
 		"@emotion/cache": "^11.14.0",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Bumping Elementor One Assets from 0.4.32 to 0.4.35 to pick up bug fixes and improvements in the component library (APP-2867).

## 2. What Changed (Where)

- `package.json`: Updated `@elementor/elementor-one-assets` dependency from 0.4.32 → 0.4.35; fixed trailing newline formatting.

## 3. How It Works

Dependency version constraint uses pinned semver (no `^` or `~`), ensuring exact version 0.4.35 is installed. No code changes needed—consumers get updated components automatically on `npm install`.

## 4. Risks

None. Patch-level bump within same minor; no breaking changes expected. Verify visual regressions in Elementor One component usage post-deploy if QA coverage is light.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
