### PR TITLE
[APP-2896] - A11y - Active installs ONE - Apps data is missing

### DIFF
--- a/modules/core/components/notificator.php
+++ b/modules/core/components/notificator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace EA11y\Modules\Core\Components;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+use Elementor\WPNotificationsPackage\V120\Notifications as Notifications_SDK;
+
+class Notificator {
+	private ?Notifications_SDK $notificator = null;
+
+	public function get_notifications_by_conditions( bool $force_request = false ): array {
+		return $this->notificator->get_notifications_by_conditions( $force_request );
+	}
+
+	public function __construct() {
+		require_once EA11Y_PATH . '/vendor/autoload.php';
+
+		$this->notificator = new Notifications_SDK( [
+			'app_name'       => 'ally',
+			'app_version'    => EA11Y_VERSION,
+			'short_app_name' => 'ally',
+			'app_data'       => [
+				'plugin_basename' => EA11Y_BASE,
+			],
+		] );
+	}
+}

--- a/modules/core/module.php
+++ b/modules/core/module.php
@@ -21,6 +21,7 @@ class Module extends Module_Base {
 			'Skip_Link',
 			'Revert_To_Legacy',
 			'Svg',
+			'Notificator',
 		];
 	}
 

--- a/tests/phpunit/plugin/modules/core/components/notificator.php
+++ b/tests/phpunit/plugin/modules/core/components/notificator.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace EA11y\Tests\Modules\Core\Components;
+
+use EA11y\Modules\Core\Components\Notificator as Tested_Component;
+use Eunit\Cases\Unit_Test;
+
+class Notificator extends Unit_Test {
+
+	private ?Tested_Component $notificator = null;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		delete_option( '_ally_notifications' );
+
+		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_filter( 'pre_http_request', [ $this, 'mock_http_request' ] );
+
+		delete_option( '_ally_notifications' );
+
+		$this->notificator = null;
+	}
+
+	public function mock_http_request( $preempt, $args, $url ) {
+		if ( strpos( $url, 'my.elementor.com/api/v1/notifications' ) === false ) {
+			return $preempt;
+		}
+
+		return [
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+			'body'     => wp_json_encode( [
+				'notifications' => [
+					[
+						'id'          => 'test-notification-1',
+						'title'       => 'Test Notification',
+						'description' => 'This is a test notification',
+						'link'        => 'https://example.com',
+					],
+				],
+			] ),
+		];
+	}
+
+	public function test_notificator_can_be_instantiated(): void {
+		$this->notificator = new Tested_Component();
+
+		$this->assertInstanceOf( Tested_Component::class, $this->notificator );
+	}
+
+	public function test_notificator_returns_notifications(): void {
+		$this->notificator = new Tested_Component();
+
+		$notifications = $this->notificator->get_notifications_by_conditions( true );
+
+		$this->assertIsArray( $notifications );
+	}
+
+	public function test_notificator_caches_notifications(): void {
+		$this->notificator = new Tested_Component();
+
+		$this->notificator->get_notifications_by_conditions( true );
+
+		$cached = get_option( '_ally_notifications' );
+
+		$this->assertNotEmpty( $cached );
+		$this->assertArrayHasKey( 'timeout', $cached );
+		$this->assertArrayHasKey( 'value', $cached );
+	}
+}

--- a/tests/phpunit/plugin/modules/core/module-test.php
+++ b/tests/phpunit/plugin/modules/core/module-test.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace EA11y\Tests\Modules\Core;
+
+use EA11y\Tests\Helpers\Module_Test_Base;
+
+/**
+ * Class Module
+ */
+class Module extends Module_Test_Base {
+	public $name = 'core';
+
+	public $components = [
+		'Pointers',
+		'Notices',
+		'Skip_Link',
+		'Revert_To_Legacy',
+		'Svg',
+		'Notificator',
+	];
+}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Accessibility data was missing from notification requests to Elementor's notification service. This PR integrates the Notifications SDK to properly fetch and cache app-specific notifications with required metadata.

## 2. What Changed (Where)

- **modules/core/components/notificator.php**: New component wrapping Elementor Notifications SDK with app metadata (ally, version, plugin basename)
- **modules/core/module.php**: Registered Notificator component in module loader
- **tests/phpunit/plugin/modules/core/**: Added unit tests for instantiation, notification retrieval, and caching behavior

## 3. How It Works

Notificator initializes Notifications SDK in constructor with required app_data fields. `get_notifications_by_conditions()` delegates to SDK, which makes HTTP requests to my.elementor.com/api/v1/notifications and caches results via WordPress options API. Tests mock HTTP responses and verify caching via `_ally_notifications` option.

## 4. Risks

Dependency on external notification service (my.elementor.com) — network failures silently degrade. Mitigation: SDK likely has retry/fallback logic; consider adding timeout constraints if not present.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
