### PR TITLE
[APP-2899] Fix: Ally legacy icon fails the new Ally checker

### DIFF
--- a/modules/legacy/components/frontend.php
+++ b/modules/legacy/components/frontend.php
@@ -114,7 +114,7 @@ class Frontend {
 		$icon = isset( $customizer_options['a11y_toolbar_icon'] ) ? $customizer_options['a11y_toolbar_icon'] : 'one-click';
 
 		?>
-		<nav id="pojo-a11y-toolbar" class="<?php echo esc_attr( implode( ' ', $wrapper_classes ) ); ?>" role="navigation">
+		<nav id="pojo-a11y-toolbar" class="<?php echo esc_attr( implode( ' ', $wrapper_classes ) ); ?>" aria-label="<?php esc_attr_e( 'Accessibility Toolbar', 'pojo-accessibility' ); ?>">
 			<div class="pojo-a11y-toolbar-toggle">
 				<a class="pojo-a11y-toolbar-link pojo-a11y-toolbar-toggle-link" href="javascript:void(0);" title="<?php echo esc_attr( $toolbar_title ); ?>" role="button">
 					<span class="pojo-sr-only sr-only"><?php esc_html_e( 'Open toolbar', 'pojo-accessibility' ); ?></span>


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Legacy Ally toolbar icon failed WCAG compliance checks due to missing `aria-label` on navigation landmark. Replaced deprecated `role="navigation"` with semantic `<nav>` element and proper labeling.

## 2. What Changed (Where)

- `modules/legacy/components/frontend.php` (line 117): Updated `<nav>` element with `aria-label="Accessibility Toolbar"` instead of generic `role="navigation"`

## 3. How It Works

The toolbar renders as a semantic HTML5 `<nav>` element with explicit `aria-label` providing accessible name to screen readers, eliminating the accessibility checker failure from ambiguous landmark roles.

## 4. Risks

None. This is a strict accessibility improvement—native `<nav>` with `aria-label` is the standard pattern and maintains backward compatibility with existing class/ID selectors.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
