### PR TITLE
[APP-2900] Fix: Heading structure in Ally admin screens

### DIFF
--- a/modules/settings/assets/js/components/alignment-matrix-control/index.js
+++ b/modules/settings/assets/js/components/alignment-matrix-control/index.js
@@ -49,7 +49,12 @@ const AlignmentMatrixControl = ({ mode }) => {
 	return (
 		<FormControl>
 			<FormLabel id="alignment-matrix-control" color="secondary">
-				<Typography variant="subtitle2" marginBottom={3} color="text.primary">
+				<Typography
+					variant="subtitle2"
+					component="span"
+					marginBottom={3}
+					color="text.primary"
+				>
 					{__('Default Position', 'pojo-accessibility')}
 				</Typography>
 			</FormLabel>

--- a/modules/settings/assets/js/components/alignment-matrix-control/index.js
+++ b/modules/settings/assets/js/components/alignment-matrix-control/index.js
@@ -49,12 +49,7 @@ const AlignmentMatrixControl = ({ mode }) => {
 	return (
 		<FormControl>
 			<FormLabel id="alignment-matrix-control" color="secondary">
-				<Typography
-					variant="subtitle2"
-					component="span"
-					marginBottom={3}
-					color="text.primary"
-				>
+				<Typography variant="subtitle2" component="div" marginBottom={3}>
 					{__('Default Position', 'pojo-accessibility')}
 				</Typography>
 			</FormLabel>

--- a/modules/settings/assets/js/components/analytics/charts-list.js
+++ b/modules/settings/assets/js/components/analytics/charts-list.js
@@ -4,11 +4,12 @@ import Alert from '@elementor/ui/Alert';
 import AlertTitle from '@elementor/ui/AlertTitle';
 import Box from '@elementor/ui/Box';
 import Button from '@elementor/ui/Button';
+import FormControl from '@elementor/ui/FormControl';
 import Grid from '@elementor/ui/Grid';
+import InputLabel from '@elementor/ui/InputLabel';
 import MenuItem from '@elementor/ui/MenuItem';
 import Select from '@elementor/ui/Select';
 import SvgIcon from '@elementor/ui/SvgIcon';
-import Typography from '@elementor/ui/Typography';
 import { styled } from '@elementor/ui/styles';
 import { AnalyticsToggle } from '@ea11y/components/analytics';
 import {
@@ -119,11 +120,12 @@ export const ChartsList = () => {
 
 			<Box display="flex" justifyContent="space-between" gap={2} width="100%">
 				<AnalyticsToggle />
-				<Box display="flex" alignItems="center" gap={2}>
-					<Typography variant="subtitle1">
+				<StyledPeriodFormControl size="small" variant="outlined">
+					<StyledPeriodLabel id="ea11y-analytics-period-label">
 						{__('Display data from', 'pojo-accessibility')}
-					</Typography>
+					</StyledPeriodLabel>
 					<Select
+						labelId="ea11y-analytics-period-label"
 						name={__('Period', 'pojo-accessibility')}
 						onChange={changePeriod}
 						value={period}
@@ -148,7 +150,7 @@ export const ChartsList = () => {
 							{__('Last 30 days', 'pojo-accessibility')}
 						</MenuItem>
 					</Select>
-				</Box>
+				</StyledPeriodFormControl>
 			</Box>
 
 			<Grid container spacing={4}>
@@ -181,6 +183,22 @@ export const ChartsList = () => {
 		</StyledBox>
 	);
 };
+
+const StyledPeriodFormControl = styled(FormControl)`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: ${({ theme }) => theme.spacing(2)};
+`;
+
+const StyledPeriodLabel = styled(InputLabel)`
+	position: static;
+	transform: none;
+	max-width: none;
+	pointer-events: none;
+	font-weight: 500;
+	color: ${({ theme }) => theme.palette.common.black};
+`;
 
 const StyledIcon = styled(SvgIcon)`
 	position: absolute;

--- a/modules/settings/assets/js/components/analytics/charts/line-chart.js
+++ b/modules/settings/assets/js/components/analytics/charts/line-chart.js
@@ -25,7 +25,7 @@ export const LineChart = () => {
 				title={<LineChartTitle />}
 				subheader={
 					totalOpen > 0 ? (
-						<Typography variant="h3" sx={{ height: '50px' }}>
+						<Typography variant="h3" component="p" sx={{ height: '50px' }}>
 							{totalOpen.toString()}
 						</Typography>
 					) : null

--- a/modules/settings/assets/js/components/analytics/components/line-chart-title.js
+++ b/modules/settings/assets/js/components/analytics/components/line-chart-title.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 
 export const LineChartTitle = () => (
 	<Box display="flex" gap={1}>
-		<Typography variant="subtitle1">
+		<Typography variant="subtitle1" component="h2">
 			{__('Widget opens', 'pojo-accessibility')}
 		</Typography>
 		<Infotip

--- a/modules/settings/assets/js/components/analytics/components/pie-chart-title.js
+++ b/modules/settings/assets/js/components/analytics/components/pie-chart-title.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 
 export const PieChartTitle = () => (
 	<Box display="flex" gap={1}>
-		<Typography variant="subtitle1">
+		<Typography variant="subtitle1" component="h2">
 			{__('Feature usage', 'pojo-accessibility')}
 		</Typography>
 		<Infotip

--- a/modules/settings/assets/js/components/analytics/components/usage-table-title.js
+++ b/modules/settings/assets/js/components/analytics/components/usage-table-title.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 
 export const UsageTableTitle = () => (
 	<Box display="flex" gap={1}>
-		<Typography variant="subtitle1">
+		<Typography variant="subtitle1" component="h2">
 			{__('Most used features', 'pojo-accessibility')}
 		</Typography>
 		<Infotip

--- a/modules/settings/assets/js/components/analytics/skeleton/line-chart-skeleton.js
+++ b/modules/settings/assets/js/components/analytics/skeleton/line-chart-skeleton.js
@@ -11,7 +11,7 @@ export const LineChartSkeleton = ({ animated }) => (
 		<CardHeader
 			title={
 				animated ? (
-					<Typography variant="subtitle1">
+					<Typography variant="subtitle1" component="h2">
 						<Skeleton
 							width={150}
 							sx={{ p: 2 }}
@@ -25,7 +25,7 @@ export const LineChartSkeleton = ({ animated }) => (
 			}
 			subheader={
 				!animated ? (
-					<Typography variant="h3" sx={{ height: '50px' }}>
+					<Typography variant="h3" component="p" sx={{ height: '50px' }}>
 						--
 					</Typography>
 				) : null

--- a/modules/settings/assets/js/components/analytics/skeleton/pie-chart-skeleton.js
+++ b/modules/settings/assets/js/components/analytics/skeleton/pie-chart-skeleton.js
@@ -26,7 +26,7 @@ export const PieChartSkeleton = ({ animated }) => {
 			<CardHeader
 				title={
 					animated ? (
-						<Typography variant="subtitle1">
+						<Typography variant="subtitle1" component="h2">
 							<Skeleton
 								width={150}
 								sx={{ p: 2 }}

--- a/modules/settings/assets/js/components/analytics/skeleton/usage-table-skeleton.js
+++ b/modules/settings/assets/js/components/analytics/skeleton/usage-table-skeleton.js
@@ -11,7 +11,7 @@ export const UsageTableSkeleton = ({ animated }) => (
 		<CardHeader
 			title={
 				animated ? (
-					<Typography variant="subtitle1">
+					<Typography variant="subtitle1" component="h2">
 						<Skeleton
 							width={150}
 							sx={{ p: 2 }}

--- a/modules/settings/assets/js/components/color-picker/index.js
+++ b/modules/settings/assets/js/components/color-picker/index.js
@@ -1,5 +1,6 @@
 import Box from '@elementor/ui/Box';
 import FormControl from '@elementor/ui/FormControl';
+import FormLabel from '@elementor/ui/FormLabel';
 import Grid from '@elementor/ui/Grid';
 import Typography from '@elementor/ui/Typography';
 import { styled } from '@elementor/ui/styles';
@@ -28,15 +29,16 @@ const ColorPicker = () => {
 
 	return (
 		<FormControl fullWidth>
-			<Typography
-				variant="subtitle2"
-				component="h3"
-				id="color-picker-label"
-				marginBottom={1}
-				color="text.primary"
-			>
-				{__('Color', 'pojo-accessibility')}
-			</Typography>
+			<FormLabel id="color-picker-label">
+				<Typography
+					variant="subtitle2"
+					component="div"
+					marginBottom={2}
+					color="text.secondary"
+				>
+					{__('Color', 'pojo-accessibility')}
+				</Typography>
+			</FormLabel>
 
 			<Grid padding={1} border={1} borderColor="divider" borderRadius={1}>
 				<HexColorPicker

--- a/modules/settings/assets/js/components/color-picker/index.js
+++ b/modules/settings/assets/js/components/color-picker/index.js
@@ -1,6 +1,5 @@
 import Box from '@elementor/ui/Box';
 import FormControl from '@elementor/ui/FormControl';
-import FormLabel from '@elementor/ui/FormLabel';
 import Grid from '@elementor/ui/Grid';
 import Typography from '@elementor/ui/Typography';
 import { styled } from '@elementor/ui/styles';
@@ -29,11 +28,15 @@ const ColorPicker = () => {
 
 	return (
 		<FormControl fullWidth>
-			<FormLabel id="color-picker-label" color="secondary">
-				<Typography variant="subtitle2" marginBottom={1} color="text.primary">
-					{__('Color', 'pojo-accessibility')}
-				</Typography>
-			</FormLabel>
+			<Typography
+				variant="subtitle2"
+				component="h3"
+				id="color-picker-label"
+				marginBottom={1}
+				color="text.primary"
+			>
+				{__('Color', 'pojo-accessibility')}
+			</Typography>
 
 			<Grid padding={1} border={1} borderColor="divider" borderRadius={1}>
 				<HexColorPicker

--- a/modules/settings/assets/js/components/color-picker/index.js
+++ b/modules/settings/assets/js/components/color-picker/index.js
@@ -29,13 +29,8 @@ const ColorPicker = () => {
 
 	return (
 		<FormControl fullWidth>
-			<FormLabel id="color-picker-label">
-				<Typography
-					variant="subtitle2"
-					component="div"
-					marginBottom={2}
-					color="text.secondary"
-				>
+			<FormLabel id="color-picker-label" color="secondary">
+				<Typography variant="subtitle2" component="div" marginBottom={2}>
 					{__('Color', 'pojo-accessibility')}
 				</Typography>
 			</FormLabel>

--- a/modules/settings/assets/js/components/icon-radius/index.js
+++ b/modules/settings/assets/js/components/icon-radius/index.js
@@ -134,7 +134,7 @@ const IconRadius = () => {
 				color="secondary"
 				aria-label={__('Widget icon radius control', 'pojo-accessibility')}
 			>
-				<Typography variant="subtitle2" component="h3" marginBottom={1}>
+				<Typography variant="subtitle2" component="div" marginBottom={1}>
 					{__('Corner radius', 'pojo-accessibility')}
 				</Typography>
 			</FormLabel>

--- a/modules/settings/assets/js/components/icon-radius/index.js
+++ b/modules/settings/assets/js/components/icon-radius/index.js
@@ -1,6 +1,7 @@
 import Box from '@elementor/ui/Box';
 import Button from '@elementor/ui/Button';
 import FormControl from '@elementor/ui/FormControl';
+import FormLabel from '@elementor/ui/FormLabel';
 import InputAdornment from '@elementor/ui/InputAdornment';
 import Menu from '@elementor/ui/Menu';
 import MenuItem from '@elementor/ui/MenuItem';
@@ -128,15 +129,15 @@ const IconRadius = () => {
 			)}
 			aria-labelledby="icon-radius-controls-group-label"
 		>
-			<Typography
-				variant="subtitle2"
-				component="h3"
+			<FormLabel
 				id="icon-radius-controls-group-label"
-				marginBottom={1}
 				color="secondary"
+				aria-label={__('Widget icon radius control', 'pojo-accessibility')}
 			>
-				{__('Corner radius', 'pojo-accessibility')}
-			</Typography>
+				<Typography variant="subtitle2" component="h3" marginBottom={1}>
+					{__('Corner radius', 'pojo-accessibility')}
+				</Typography>
+			</FormLabel>
 
 			<StyledBox>
 				<StyledTextField

--- a/modules/settings/assets/js/components/icon-radius/index.js
+++ b/modules/settings/assets/js/components/icon-radius/index.js
@@ -1,7 +1,6 @@
 import Box from '@elementor/ui/Box';
 import Button from '@elementor/ui/Button';
 import FormControl from '@elementor/ui/FormControl';
-import FormLabel from '@elementor/ui/FormLabel';
 import InputAdornment from '@elementor/ui/InputAdornment';
 import Menu from '@elementor/ui/Menu';
 import MenuItem from '@elementor/ui/MenuItem';
@@ -129,15 +128,15 @@ const IconRadius = () => {
 			)}
 			aria-labelledby="icon-radius-controls-group-label"
 		>
-			<FormLabel
+			<Typography
+				variant="subtitle2"
+				component="h3"
 				id="icon-radius-controls-group-label"
+				marginBottom={1}
 				color="secondary"
-				aria-label={__('Widget icon radius control', 'pojo-accessibility')}
 			>
-				<Typography variant="subtitle2" marginBottom={1}>
-					{__('Corner radius', 'pojo-accessibility')}
-				</Typography>
-			</FormLabel>
+				{__('Corner radius', 'pojo-accessibility')}
+			</Typography>
 
 			<StyledBox>
 				<StyledTextField

--- a/modules/settings/assets/js/components/icon-select/index.js
+++ b/modules/settings/assets/js/components/icon-select/index.js
@@ -1,5 +1,5 @@
+import Box from '@elementor/ui/Box';
 import FormControl from '@elementor/ui/FormControl';
-import FormLabel from '@elementor/ui/FormLabel';
 import RadioGroup from '@elementor/ui/RadioGroup';
 import Typography from '@elementor/ui/Typography';
 import { styled } from '@elementor/ui/styles';
@@ -22,11 +22,13 @@ const IconSelect = (props) => {
 
 	return (
 		<FormControl>
-			<StyledFormLabel
-				id="icon-select-radio-buttons-group-label"
-				color="secondary"
-			>
-				<Typography variant="subtitle2" marginBottom={1}>
+			<StyledFormLabel>
+				<Typography
+					variant="subtitle2"
+					component="h3"
+					id="icon-select-radio-buttons-group-label"
+					marginBottom={1}
+				>
 					{__('Icon', 'pojo-accessibility')}
 				</Typography>
 				<MediaUploader />
@@ -61,7 +63,7 @@ const StyledRadioGroup = styled(RadioGroup)`
 	gap: ${({ theme }) => theme.spacing(2)};
 `;
 
-const StyledFormLabel = styled(FormLabel)`
+const StyledFormLabel = styled(Box)`
 	display: flex;
 	flex-direction: row;
 	flex-wrap: nowrap;

--- a/modules/settings/assets/js/components/icon-select/index.js
+++ b/modules/settings/assets/js/components/icon-select/index.js
@@ -1,5 +1,5 @@
-import Box from '@elementor/ui/Box';
 import FormControl from '@elementor/ui/FormControl';
+import FormLabel from '@elementor/ui/FormLabel';
 import RadioGroup from '@elementor/ui/RadioGroup';
 import Typography from '@elementor/ui/Typography';
 import { styled } from '@elementor/ui/styles';
@@ -22,13 +22,11 @@ const IconSelect = (props) => {
 
 	return (
 		<FormControl>
-			<StyledFormLabel>
-				<Typography
-					variant="subtitle2"
-					component="h3"
-					id="icon-select-radio-buttons-group-label"
-					marginBottom={1}
-				>
+			<StyledFormLabel
+				id="icon-select-radio-buttons-group-label"
+				color="secondary"
+			>
+				<Typography variant="subtitle2" component="h3" marginBottom={1}>
 					{__('Icon', 'pojo-accessibility')}
 				</Typography>
 				<MediaUploader />
@@ -63,7 +61,7 @@ const StyledRadioGroup = styled(RadioGroup)`
 	gap: ${({ theme }) => theme.spacing(2)};
 `;
 
-const StyledFormLabel = styled(Box)`
+const StyledFormLabel = styled(FormLabel)`
 	display: flex;
 	flex-direction: row;
 	flex-wrap: nowrap;

--- a/modules/settings/assets/js/components/icon-select/index.js
+++ b/modules/settings/assets/js/components/icon-select/index.js
@@ -26,7 +26,7 @@ const IconSelect = (props) => {
 				id="icon-select-radio-buttons-group-label"
 				color="secondary"
 			>
-				<Typography variant="subtitle2" component="h3" marginBottom={1}>
+				<Typography variant="subtitle2" component="div" marginBottom={1}>
 					{__('Icon', 'pojo-accessibility')}
 				</Typography>
 				<MediaUploader />

--- a/modules/settings/assets/js/components/icon-size/index.js
+++ b/modules/settings/assets/js/components/icon-size/index.js
@@ -1,5 +1,4 @@
 import FormControl from '@elementor/ui/FormControl';
-import FormLabel from '@elementor/ui/FormLabel';
 import RadioGroup from '@elementor/ui/RadioGroup';
 import Typography from '@elementor/ui/Typography';
 import { IconOptionWrapper } from '@ea11y/components';
@@ -25,11 +24,15 @@ const IconSize = (props) => {
 
 	return (
 		<FormControl>
-			<FormLabel id="icon-size-radio-buttons-group-label" color="secondary">
-				<Typography variant="subtitle2" marginBottom={1}>
-					{__('Size', 'pojo-accessibility')}
-				</Typography>
-			</FormLabel>
+			<Typography
+				variant="subtitle2"
+				component="h3"
+				id="icon-size-radio-buttons-group-label"
+				marginBottom={1}
+				color="secondary"
+			>
+				{__('Size', 'pojo-accessibility')}
+			</Typography>
 
 			<RadioGroup
 				{...props}

--- a/modules/settings/assets/js/components/icon-size/index.js
+++ b/modules/settings/assets/js/components/icon-size/index.js
@@ -26,7 +26,7 @@ const IconSize = (props) => {
 	return (
 		<FormControl>
 			<FormLabel id="icon-size-radio-buttons-group-label" color="secondary">
-				<Typography variant="subtitle2" component="h3" marginBottom={1}>
+				<Typography variant="subtitle2" component="div" marginBottom={1}>
 					{__('Size', 'pojo-accessibility')}
 				</Typography>
 			</FormLabel>

--- a/modules/settings/assets/js/components/icon-size/index.js
+++ b/modules/settings/assets/js/components/icon-size/index.js
@@ -1,4 +1,5 @@
 import FormControl from '@elementor/ui/FormControl';
+import FormLabel from '@elementor/ui/FormLabel';
 import RadioGroup from '@elementor/ui/RadioGroup';
 import Typography from '@elementor/ui/Typography';
 import { IconOptionWrapper } from '@ea11y/components';
@@ -24,15 +25,11 @@ const IconSize = (props) => {
 
 	return (
 		<FormControl>
-			<Typography
-				variant="subtitle2"
-				component="h3"
-				id="icon-size-radio-buttons-group-label"
-				marginBottom={1}
-				color="secondary"
-			>
-				{__('Size', 'pojo-accessibility')}
-			</Typography>
+			<FormLabel id="icon-size-radio-buttons-group-label" color="secondary">
+				<Typography variant="subtitle2" component="h3" marginBottom={1}>
+					{__('Size', 'pojo-accessibility')}
+				</Typography>
+			</FormLabel>
 
 			<RadioGroup
 				{...props}

--- a/modules/settings/assets/js/components/skip-to-content-settings/index.js
+++ b/modules/settings/assets/js/components/skip-to-content-settings/index.js
@@ -78,6 +78,7 @@ const SkipToContentSettings = () => {
 			<StyledBox>
 				<StyledTypography
 					variant="subtitle1"
+					component="h2"
 					id="ea11y-skip-to-content-toggle"
 					aria-description={titleTooltipText}
 				>

--- a/modules/settings/assets/js/components/widget-activation-settings/index.js
+++ b/modules/settings/assets/js/components/widget-activation-settings/index.js
@@ -37,6 +37,7 @@ const WidgetActivationSettings = () => {
 			<StyledBox>
 				<StyledTypography
 					variant="subtitle1"
+					component="h2"
 					id="ea11y-widget-activation-toggle"
 				>
 					{__('Widget Activation', 'pojo-accessibility')}

--- a/modules/settings/assets/js/layouts/icon-design-settings.js
+++ b/modules/settings/assets/js/layouts/icon-design-settings.js
@@ -14,7 +14,7 @@ const IconDesignSettings = (props) => {
 	return (
 		<StyledWrapper {...props}>
 			<Box marginBottom={2}>
-				<Typography variant="subtitle1">
+				<Typography variant="subtitle1" component="h2">
 					{__('Style', 'pojo-accessibility')}
 				</Typography>
 

--- a/modules/settings/assets/js/layouts/logo-settings.js
+++ b/modules/settings/assets/js/layouts/logo-settings.js
@@ -35,6 +35,7 @@ const LogoSettings = () => {
 						)}
 					</>
 				}
+				titleTypographyProps={{ component: 'h2' }}
 				subheader={
 					<Typography variant="body2">
 						{__(

--- a/modules/settings/assets/js/layouts/menu-settings.js
+++ b/modules/settings/assets/js/layouts/menu-settings.js
@@ -72,6 +72,7 @@ const MenuSettings = () => {
 			<Card variant="outlined">
 				<CardHeader
 					title={__('Feature Menu', 'pojo-accessibility')}
+					titleTypographyProps={{ component: 'h2' }}
 					subheader={
 						<Typography variant="body2">
 							{__(
@@ -99,7 +100,7 @@ const MenuSettings = () => {
 								<Box key={parentKey}>
 									<ListItem as="div" disableGutters>
 										<ListItemText sx={{ textAlign: 'start' }}>
-											<Typography variant="subtitle2">
+											<Typography variant="subtitle2" component="h3">
 												{parentItem.title}
 											</Typography>
 										</ListItemText>

--- a/modules/settings/assets/js/layouts/position-settings-desktop.js
+++ b/modules/settings/assets/js/layouts/position-settings-desktop.js
@@ -39,13 +39,23 @@ const PositionSettingsDesktop = () => {
 	};
 
 	const hideOnDesktopLabel = (
-		<Typography variant="subtitle2" marginRight={2} color="text.primary">
+		<Typography
+			variant="subtitle2"
+			component="span"
+			marginRight={2}
+			color="text.primary"
+		>
 			{__('Hide on desktop', 'pojo-accessibility')}
 		</Typography>
 	);
 
 	const exactPositionLabel = (
-		<Typography variant="subtitle2" color="text.primary" marginRight={2}>
+		<Typography
+			variant="subtitle2"
+			component="span"
+			color="text.primary"
+			marginRight={2}
+		>
 			{__('Exact position', 'pojo-accessibility')}
 		</Typography>
 	);

--- a/modules/settings/assets/js/layouts/position-settings-mobile.js
+++ b/modules/settings/assets/js/layouts/position-settings-mobile.js
@@ -37,13 +37,23 @@ const PositionSettingsMobile = () => {
 	};
 
 	const hideOnMobileLabel = (
-		<Typography variant="subtitle2" color="text.primary" marginRight={2}>
+		<Typography
+			variant="subtitle2"
+			component="span"
+			color="text.primary"
+			marginRight={2}
+		>
 			{__('Hide on mobile', 'pojo-accessibility')}
 		</Typography>
 	);
 
 	const exactPositionLabel = (
-		<Typography variant="subtitle2" color="text.primary" marginRight={2}>
+		<Typography
+			variant="subtitle2"
+			component="span"
+			color="text.primary"
+			marginRight={2}
+		>
 			{__('Exact position', 'pojo-accessibility')}
 		</Typography>
 	);

--- a/modules/settings/assets/js/layouts/position-settings.js
+++ b/modules/settings/assets/js/layouts/position-settings.js
@@ -31,7 +31,7 @@ export const PositionSettings = (props) => {
 	return (
 		<StyledWrapper {...props}>
 			<Box marginBottom={2}>
-				<Typography variant="subtitle1">
+				<Typography variant="subtitle1" component="h2">
 					{__('Position', 'pojo-accessibility')}
 				</Typography>
 				<Typography variant="body2">

--- a/modules/settings/assets/js/layouts/statement-link/index.js
+++ b/modules/settings/assets/js/layouts/statement-link/index.js
@@ -139,6 +139,7 @@ const StatementLink = () => {
 		<Card elevation={0} variant="outlined" sx={{ marginTop: 1, width: '100%' }}>
 			<CardHeader
 				title={__('Statement link', 'pojo-accessibility')}
+				titleTypographyProps={{ component: 'h2' }}
 				subheader={__(
 					'Link your accessibility statement page to your accessibility widget.',
 					'pojo-accessibility',
@@ -151,7 +152,11 @@ const StatementLink = () => {
 					<Box display="flex" flexDirection="column">
 						<FormControl fullWidth sx={{ marginBottom: 2 }}>
 							<FormLabel sx={{ marginBottom: 1 }}>
-								<Typography variant="subtitle2" color="text.primary">
+								<Typography
+									variant="subtitle2"
+									component="span"
+									color="text.primary"
+								>
 									{__('Choose which page to link', 'pojo-accessibility')}
 								</Typography>
 							</FormLabel>
@@ -181,7 +186,11 @@ const StatementLink = () => {
 
 						<FormControl fullWidth>
 							<FormLabel sx={{ marginBottom: 2, marginTop: 2 }}>
-								<Typography variant="subtitle2" color="text.primary">
+								<Typography
+									variant="subtitle2"
+									component="span"
+									color="text.primary"
+								>
 									{__('Want to hide the link?', 'pojo-accessibility')}
 								</Typography>
 							</FormLabel>
@@ -204,7 +213,11 @@ const StatementLink = () => {
 					</Box>
 
 					<Box>
-						<Typography variant="subtitle2" color="text.primary">
+						<Typography
+							variant="subtitle2"
+							component="span"
+							color="text.primary"
+						>
 							{__('Preview link in widget', 'pojo-accessibility')}
 						</Typography>
 

--- a/modules/settings/assets/js/layouts/widget-preview/index.js
+++ b/modules/settings/assets/js/layouts/widget-preview/index.js
@@ -47,6 +47,7 @@ const WidgetPreview = () => {
 			<Card variant="outlined">
 				<CardHeader
 					title={__('Preview', 'pojo-accessibility')}
+					titleTypographyProps={{ component: 'h2' }}
 					subheader={
 						<Typography variant="body2">
 							{__(

--- a/modules/settings/assets/js/pages/accessibility-statement.js
+++ b/modules/settings/assets/js/pages/accessibility-statement.js
@@ -77,7 +77,7 @@ const AccessibilityStatement = () => {
 		<>
 			<StyledBox>
 				<StyledWideBox>
-					<StyledPageTitle variant="h5">
+					<StyledPageTitle variant="h5" component="h1">
 						{__('Accessibility statement', 'pojo-accessibility')}
 					</StyledPageTitle>
 
@@ -124,6 +124,7 @@ const AccessibilityStatement = () => {
 								>
 									<Typography
 										variant="h6"
+										component="h2"
 										color="text.primary"
 										align="center"
 										marginBottom="4px"

--- a/modules/settings/assets/js/pages/analytics.js
+++ b/modules/settings/assets/js/pages/analytics.js
@@ -24,7 +24,7 @@ const Analytics = () => {
 	return (
 		<StyledBox sx={{ position: 'relative' }}>
 			<StyledWideBox>
-				<StyledPageTitle variant="h5">
+				<StyledPageTitle variant="h5" component="h1">
 					{__('Analytics', 'pojo-accessibility')}
 				</StyledPageTitle>
 				<ChartsList />

--- a/modules/settings/assets/js/pages/assistant/heading.js
+++ b/modules/settings/assets/js/pages/assistant/heading.js
@@ -18,7 +18,7 @@ const AccessibilityAssistantHeading = ({
 
 	return (
 		<StyledHeadingContainer>
-			<StyledTitle variant="h5">
+			<StyledTitle variant="h5" component="h1">
 				{__('Accessibility scans', 'pojo-accessibility')}
 
 				<Chip

--- a/modules/settings/assets/js/pages/assistant/no-results-state.js
+++ b/modules/settings/assets/js/pages/assistant/no-results-state.js
@@ -13,7 +13,7 @@ const AccessibilityAssistantNoResultsState = () => {
 			<StyledWrapper>
 				<AccessibilityAssistantNoResultsIcon />
 
-				<StyledTitle variant="subtitle1" as="h3">
+				<StyledTitle variant="subtitle1" as="h2">
 					{__('No matching results found', 'pojo-accessibility')}
 				</StyledTitle>
 
@@ -31,7 +31,7 @@ const AccessibilityAssistantNoResultsState = () => {
 		<StyledWrapper>
 			<AccessibilityAssistantNoResultsIcon />
 
-			<StyledTitle variant="subtitle1" as="h3">
+			<StyledTitle variant="subtitle1" as="h2">
 				{__('No data to display for this period', 'pojo-accessibility')}
 			</StyledTitle>
 

--- a/modules/settings/assets/js/pages/assistant/stats/issues-by-category/index.js
+++ b/modules/settings/assets/js/pages/assistant/stats/issues-by-category/index.js
@@ -20,7 +20,7 @@ const IssuesByCategory = ({ stats, loading, noResultsState }) => {
 	return (
 		<StyledStatsItem className="resolved-issues-by-category">
 			<StyledStatsItemContent>
-				<StyledStatsItemTitle variant="subtitle1" as="p" spacing={3}>
+				<StyledStatsItemTitle variant="subtitle1" as="h2" spacing={3}>
 					{__('Resolved issues by category', 'pojo-accessibility')}
 
 					<AccessibilityAssistantTooltip

--- a/modules/settings/assets/js/pages/assistant/stats/issues-by-level/index.js
+++ b/modules/settings/assets/js/pages/assistant/stats/issues-by-level/index.js
@@ -35,7 +35,7 @@ const IssuesByLevel = ({ stats, loading, noResultsState }) => {
 	return (
 		<StyledStatsItem className="resolved-issues-by-level">
 			<StyledStatsItemContent>
-				<StyledStatsItemTitle variant="subtitle1" as="p" spacing={3}>
+				<StyledStatsItemTitle variant="subtitle1" as="h2" spacing={3}>
 					{__('Resolved issues by level', 'pojo-accessibility')}
 
 					<AccessibilityAssistantTooltip

--- a/modules/settings/assets/js/pages/assistant/stats/stats-counter.js
+++ b/modules/settings/assets/js/pages/assistant/stats/stats-counter.js
@@ -11,7 +11,7 @@ const StatsCounter = ({ stat, loading, title, tooltip }) => {
 	return (
 		<StyledStatsItem className="scanned-urls">
 			<StyledStatsItemContent>
-				<StyledStatsItemTitle variant="subtitle1" as="p">
+				<StyledStatsItemTitle variant="subtitle1" as="h2">
 					{title}
 
 					<AccessibilityAssistantTooltip content={tooltip} />

--- a/modules/settings/assets/js/pages/icon-settings.js
+++ b/modules/settings/assets/js/pages/icon-settings.js
@@ -20,7 +20,7 @@ const IconSettings = () => {
 	return (
 		<StyledBox>
 			<StyledWideBox>
-				<StyledPageTitle variant="h5">
+				<StyledPageTitle variant="h5" component="h1">
 					{__('Design', 'pojo-accessibility')}
 				</StyledPageTitle>
 

--- a/modules/settings/assets/js/pages/menu.js
+++ b/modules/settings/assets/js/pages/menu.js
@@ -22,7 +22,7 @@ const Menu = () => {
 	return (
 		<StyledBox>
 			<StyledWideBox>
-				<StyledPageTitle variant="h5">
+				<StyledPageTitle variant="h5" component="h1">
 					{__('Capabilities', 'pojo-accessibility')}
 				</StyledPageTitle>
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Fixing heading hierarchy across admin screens for WCAG compliance. Page titles now render as `h1`, section headers as `h2`/`h3`, and labels properly semantic with `component` prop.

## 2. What Changed (Where)

| Category | Changes |
|----------|---------|
| Page titles | Added `component="h1"` to 6 page-level Typography/StyledPageTitle components (analytics, accessibility-statement, icon-settings, menu, assistant heading) |
| Section headers | Added `component="h2"` to 10+ subsection headers (widget-activation, skip-to-content, menu items, chart titles, stats titles) |
| Form labels | Wrapped 8+ form labels with Typography `component="div"` or `component="span"` and semantic `h3` for nested sections |
| Analytics refactor | Replaced Box+Typography layout with FormControl+InputLabel for period selector; added 2 styled components |

## 3. How It Works

Semantic HTML hierarchy now flows: `<h1>` page title → `<h2>` major sections → `<h3>` subsections. Form labels use proper ARIA attributes (`labelId` references). Typography `component` prop overrides default `<p>` rendering without affecting visual styling. No structural DOM changes—pure semantic layer upgrade.

## 4. Risks

Import churn in analytics/charts-list.js (removed Typography, added FormControl/InputLabel) could shadow similar names elsewhere—verify no namespace collisions. Styled components `StyledPeriodFormControl` and `StyledPeriodLabel` add CSS burden; `position: static` override is intentional for label reflow but test responsive behavior on narrow viewports.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
