### PR TITLE
[APP-2902] Fix: PHPUnit tests use wrong WordPress versions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
-        wp: [6.6.x, 6.7.x, 6.8.x, latest, nightly]
+        wp: [6.7.x, 6.8.x, 6.9.x, latest, nightly]
         ms: [no, yes]
         coverage: [no]
         phpunit: [9]


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
PHPUnit matrix was testing against outdated WordPress 6.6.x; bumping minimum to 6.7.x aligns testing with currently supported versions.

## 2. What Changed (Where)
`.github/workflows/phpunit.yml`: WordPress test matrix updated from `[6.6.x, 6.7.x, 6.8.x, latest, nightly]` to `[6.7.x, 6.8.x, 6.9.x, latest, nightly]`.

## 4. Risks
Minor—drops 6.6.x coverage but likely already out of support; verify no active projects require 6.6.x compatibility before merge.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
