### PR TITLE
[APP-2874] change mixpanel host

### DIFF
--- a/assets/dev/js/services/mixpanel/mixpanel-service.js
+++ b/assets/dev/js/services/mixpanel/mixpanel-service.js
@@ -1,5 +1,6 @@
 const SHARE_USAGE_DATA = 'share_usage_data';
 const MIXPANEL_TOKEN = '150605b3b9f979922f2ac5a52e2dcfe9';
+const MIXPANEL_HOST = 'https://api-eu.mixpanel.com';
 
 let mixpanel = null;
 
@@ -29,6 +30,7 @@ const init = async () => {
 		ea11ySettingsData?.pluginVersion || ea11yScannerData?.pluginVersion;
 
 	await mixpanel.init(MIXPANEL_TOKEN, {
+		api_host: MIXPANEL_HOST,
 		debug: pluginEnv === 'dev',
 		track_pageview: false,
 		persistence: 'localStorage',


### PR DESCRIPTION
<img width="2322" height="1166" alt="image" src="https://github.com/user-attachments/assets/ef703312-55b2-4f32-887e-0126fcf4714c" />

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Switching Mixpanel analytics endpoint from default US region to EU region via explicit host configuration. Required for data residency compliance or latency optimization.

## 2. What Changed (Where)
- `mixpanel-service.js`: Added `MIXPANEL_HOST` constant and passed `api_host` config to `mixpanel.init()`.

## 3. How It Works
New constant specifies EU API endpoint; passed as `api_host` parameter during Mixpanel initialization to route all analytics requests to EU servers instead of default.

## 4. Risks
No material risks—straightforward configuration change. Verify EU endpoint is production-ready and available before deploying.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
