### PR TITLE
[APP-2473] Update review UI with updated design

### DIFF
--- a/assets/dev/js/services/mixpanel/mixpanel-events.js
+++ b/assets/dev/js/services/mixpanel/mixpanel-events.js
@@ -71,6 +71,8 @@ export const mixpanelEvents = {
 		starSelected: 'review_star_selected',
 		feedbackSubmitted: 'review_feedback_submitted',
 		publicRedirectClicked: 'review_public_redirect_clicked',
+		callPromptDismissed: 'review_feedback_call_prompt_dismissed',
+		callScheduleClicked: 'review_feedback_call_schedule_clicked',
 	},
 
 	// Heading Structure

--- a/modules/reviews/assets/src/components/dismiss-button.js
+++ b/modules/reviews/assets/src/components/dismiss-button.js
@@ -2,13 +2,23 @@ import Box from '@elementor/ui/Box';
 import Button from '@elementor/ui/Button';
 import CloseButton from '@elementor/ui/CloseButton';
 import { useStorage } from '@ea11y-apps/global/hooks';
+import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { date } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
+import { SCHEDULING_LINK } from '../constants';
 import { useSettings } from '../hooks/use-settings';
 
 const DismissButton = ({ variant = 'icon' }) => {
 	const { save, get } = useStorage();
-	const { currentPage, setIsOpened, handleClose, handleSubmit } = useSettings();
+	const {
+		currentPage,
+		rating,
+		setIsOpened,
+		setCurrentPage,
+		handleClose,
+		handleSubmit,
+	} = useSettings();
+
 	const handleDismiss = async () => {
 		if (get.hasFinishedResolution) {
 			await save({
@@ -24,24 +34,75 @@ const DismissButton = ({ variant = 'icon' }) => {
 		setIsOpened(false);
 	};
 
+	const handleMaybeLater = async () => {
+		mixpanelService.sendEvent(mixpanelEvents.review.callPromptDismissed, {
+			rating: parseInt(rating),
+		});
+
+		await handleDismiss();
+	};
+
+	const handlePickATime = async () => {
+		mixpanelService.sendEvent(mixpanelEvents.review.callScheduleClicked, {
+			rating: parseInt(rating),
+		});
+
+		await save({
+			ea11y_review_data: {
+				...get.data.ea11y_review_data,
+				repo_review_clicked: true,
+			},
+		});
+
+		setIsOpened(false);
+		window.open(SCHEDULING_LINK, '_blank');
+	};
+
+	const handleFeedbackSubmit = async () => {
+		const submitted = await handleSubmit(handleClose, true);
+
+		if (submitted) {
+			setCurrentPage('thanks');
+		}
+	};
+
 	if ('icon' === variant) {
 		return <CloseButton onClick={handleDismiss} />;
 	}
 
-	if ('button' === variant) {
-		return (
-			<Box
-				display="flex"
-				flexDirection="row"
-				gap={1}
-				p={currentPage === 'feedback' ? 2 : 0}
-				width="100%"
-				justifyContent="end"
+	const renderCallSchedulingButtons = () => (
+		<>
+			<Button
+				color="secondary"
+				variant="text"
+				sx={{ p: 0.5 }}
+				onClick={handleMaybeLater}
+				size="small"
 			>
+				{__('Maybe later', 'pojo-accessibility')}
+			</Button>
+			<Button
+				color="secondary"
+				variant="contained"
+				onClick={handlePickATime}
+				size="small"
+			>
+				{__('Pick a time', 'pojo-accessibility')}
+			</Button>
+		</>
+	);
+
+	const renderFooterButtons = () => {
+		if (currentPage === 'thanks') {
+			return renderCallSchedulingButtons();
+		}
+
+		return (
+			<>
 				<Button
 					color="secondary"
 					variant="text"
-					fullWidth={currentPage === 'feedback' ? false : true}
+					fullWidth={currentPage !== 'feedback'}
 					sx={{ p: currentPage === 'feedback' ? 0.5 : 2 }}
 					onClick={handleDismiss}
 					size="small"
@@ -52,12 +113,30 @@ const DismissButton = ({ variant = 'icon' }) => {
 					<Button
 						color="secondary"
 						variant="contained"
-						onClick={() => handleSubmit(handleClose)}
+						onClick={handleFeedbackSubmit}
 						size="small"
 					>
 						{__('Submit', 'pojo-accessibility')}
 					</Button>
 				)}
+			</>
+		);
+	};
+
+	if ('button' === variant) {
+		const isTwoButtonLayout =
+			currentPage === 'feedback' || currentPage === 'thanks';
+
+		return (
+			<Box
+				display="flex"
+				flexDirection="row"
+				gap={1}
+				p={isTwoButtonLayout ? 2 : 0}
+				width="100%"
+				justifyContent="end"
+			>
+				{renderFooterButtons()}
 			</Box>
 		);
 	}

--- a/modules/reviews/assets/src/components/dismiss-button.js
+++ b/modules/reviews/assets/src/components/dismiss-button.js
@@ -59,6 +59,14 @@ const DismissButton = ({ variant = 'icon' }) => {
 		window.open(SCHEDULING_LINK, '_blank');
 	};
 
+	const handleNotNowOnFeedback = async () => {
+		const submitted = await handleSubmit(handleClose, true);
+
+		if (submitted) {
+			setCurrentPage(PAGE_IDS.THANKS);
+		}
+	};
+
 	const handleFeedbackSubmit = async () => {
 		const submitted = await handleSubmit(handleClose, true);
 
@@ -105,7 +113,11 @@ const DismissButton = ({ variant = 'icon' }) => {
 					variant="text"
 					fullWidth={currentPage !== PAGE_IDS.FEEDBACK}
 					sx={{ p: currentPage === PAGE_IDS.FEEDBACK ? 0.5 : 2 }}
-					onClick={handleDismiss}
+					onClick={
+						currentPage === PAGE_IDS.FEEDBACK
+							? handleNotNowOnFeedback
+							: handleDismiss
+					}
 					size="small"
 				>
 					{__('Not now', 'pojo-accessibility')}

--- a/modules/reviews/assets/src/components/dismiss-button.js
+++ b/modules/reviews/assets/src/components/dismiss-button.js
@@ -1,11 +1,12 @@
 import Box from '@elementor/ui/Box';
 import Button from '@elementor/ui/Button';
 import CloseButton from '@elementor/ui/CloseButton';
+import { styled } from '@elementor/ui/styles';
 import { useStorage } from '@ea11y-apps/global/hooks';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { date } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
-import { SCHEDULING_LINK } from '../constants';
+import { PAGE_IDS, SCHEDULING_LINK } from '../constants';
 import { useSettings } from '../hooks/use-settings';
 
 const DismissButton = ({ variant = 'icon' }) => {
@@ -62,7 +63,7 @@ const DismissButton = ({ variant = 'icon' }) => {
 		const submitted = await handleSubmit(handleClose, true);
 
 		if (submitted) {
-			setCurrentPage('thanks');
+			setCurrentPage(PAGE_IDS.THANKS);
 		}
 	};
 
@@ -93,7 +94,7 @@ const DismissButton = ({ variant = 'icon' }) => {
 	);
 
 	const renderFooterButtons = () => {
-		if (currentPage === 'thanks') {
+		if (currentPage === PAGE_IDS.THANKS) {
 			return renderCallSchedulingButtons();
 		}
 
@@ -102,14 +103,14 @@ const DismissButton = ({ variant = 'icon' }) => {
 				<Button
 					color="secondary"
 					variant="text"
-					fullWidth={currentPage !== 'feedback'}
-					sx={{ p: currentPage === 'feedback' ? 0.5 : 2 }}
+					fullWidth={currentPage !== PAGE_IDS.FEEDBACK}
+					sx={{ p: currentPage === PAGE_IDS.FEEDBACK ? 0.5 : 2 }}
 					onClick={handleDismiss}
 					size="small"
 				>
 					{__('Not now', 'pojo-accessibility')}
 				</Button>
-				{currentPage === 'feedback' && (
+				{currentPage === PAGE_IDS.FEEDBACK && (
 					<Button
 						color="secondary"
 						variant="contained"
@@ -125,21 +126,26 @@ const DismissButton = ({ variant = 'icon' }) => {
 
 	if ('button' === variant) {
 		const isTwoButtonLayout =
-			currentPage === 'feedback' || currentPage === 'thanks';
+			currentPage === PAGE_IDS.FEEDBACK || currentPage === PAGE_IDS.THANKS;
 
 		return (
-			<Box
-				display="flex"
-				flexDirection="row"
-				gap={1}
-				p={isTwoButtonLayout ? 2 : 0}
-				width="100%"
-				justifyContent="end"
-			>
+			<StyledButtonContainer isTwoButtonLayout={isTwoButtonLayout}>
 				{renderFooterButtons()}
-			</Box>
+			</StyledButtonContainer>
 		);
 	}
 };
 
 export default DismissButton;
+
+const StyledButtonContainer = styled(Box, {
+	shouldForwardProp: (prop) => prop !== 'isTwoButtonLayout',
+})`
+	display: flex;
+	flex-direction: row;
+	gap: ${({ theme }) => theme.spacing(1)};
+	padding: ${({ isTwoButtonLayout, theme }) =>
+		isTwoButtonLayout ? theme.spacing(2) : 0};
+	width: 100%;
+	justify-content: end;
+`;

--- a/modules/reviews/assets/src/components/rating-form.js
+++ b/modules/reviews/assets/src/components/rating-form.js
@@ -59,7 +59,7 @@ const RatingForm = () => {
 			const submitted = await handleSubmit(handleClose, true, ratingValue);
 
 			if (submitted) {
-				setCurrentPage('review');
+				setCurrentPage('thanks');
 			}
 		}
 	};

--- a/modules/reviews/assets/src/components/rating-form.js
+++ b/modules/reviews/assets/src/components/rating-form.js
@@ -6,6 +6,7 @@ import Radio from '@elementor/ui/Radio';
 import RadioGroup from '@elementor/ui/RadioGroup';
 import { styled } from '@elementor/ui/styles';
 import { __ } from '@wordpress/i18n';
+import { PAGE_IDS } from '../constants';
 import { useSettings } from '../hooks/use-settings';
 import {
 	MoodEmpty,
@@ -54,12 +55,12 @@ const RatingForm = () => {
 
 	const handleNextButton = async (ratingValue) => {
 		if (ratingValue < 4) {
-			setCurrentPage('feedback');
+			setCurrentPage(PAGE_IDS.FEEDBACK);
 		} else {
 			const submitted = await handleSubmit(handleClose, true, ratingValue);
 
 			if (submitted) {
-				setCurrentPage('thanks');
+				setCurrentPage(PAGE_IDS.THANKS);
 			}
 		}
 	};

--- a/modules/reviews/assets/src/components/thanks-form.js
+++ b/modules/reviews/assets/src/components/thanks-form.js
@@ -8,7 +8,7 @@ const ThanksForm = () => {
 	return (
 		<StyledFormControl fullWidth>
 			<StyledMoodHappy />
-			<Typography variant="h6" marginBlockEnd={1}>
+			<Typography variant="h6" marginBlockEnd={1} component="h6">
 				{__('Thanks for letting us know', 'pojo-accessibility')}
 			</Typography>
 			<Typography

--- a/modules/reviews/assets/src/components/thanks-form.js
+++ b/modules/reviews/assets/src/components/thanks-form.js
@@ -1,27 +1,13 @@
 import FormControl from '@elementor/ui/FormControl';
 import Typography from '@elementor/ui/Typography';
+import { styled } from '@elementor/ui/styles';
 import { __ } from '@wordpress/i18n';
 import { MoodHappy } from '../icons';
 
 const ThanksForm = () => {
 	return (
-		<FormControl
-			sx={{
-				display: 'flex',
-				alignItems: 'center',
-				gap: 1,
-				textAlign: 'center',
-			}}
-			fullWidth
-		>
-			<MoodHappy
-				sx={{
-					p: 1.5,
-					backgroundColor: '#f3f3f4',
-					borderRadius: 2,
-					fontSize: 24,
-				}}
-			/>
+		<StyledFormControl fullWidth>
+			<StyledMoodHappy />
 			<Typography variant="h6" marginBlockEnd={1}>
 				{__('Thanks for letting us know', 'pojo-accessibility')}
 			</Typography>
@@ -35,8 +21,22 @@ const ThanksForm = () => {
 				<br />
 				{__('Open to a quick call?', 'pojo-accessibility')}
 			</Typography>
-		</FormControl>
+		</StyledFormControl>
 	);
 };
 
 export default ThanksForm;
+
+const StyledFormControl = styled(FormControl)`
+	display: flex;
+	align-items: center;
+	gap: ${({ theme }) => theme.spacing(1)};
+	text-align: center;
+`;
+
+const StyledMoodHappy = styled(MoodHappy)`
+	padding: ${({ theme }) => theme.spacing(1.5)};
+	background-color: #f3f3f4;
+	border-radius: ${({ theme }) => theme.spacing(2)};
+	font-size: 24px;
+`;

--- a/modules/reviews/assets/src/components/thanks-form.js
+++ b/modules/reviews/assets/src/components/thanks-form.js
@@ -2,14 +2,20 @@ import FormControl from '@elementor/ui/FormControl';
 import Typography from '@elementor/ui/Typography';
 import { styled } from '@elementor/ui/styles';
 import { __ } from '@wordpress/i18n';
-import { MoodHappy } from '../icons';
+import { useSettings } from '../hooks/use-settings';
+import { MoodHappy, MoodSad } from '../icons';
 
 const ThanksForm = () => {
+	const { rating } = useSettings();
+	const isPositiveRating = parseInt(rating, 10) >= 4;
+
 	return (
 		<StyledFormControl fullWidth>
-			<StyledMoodHappy />
-			<Typography variant="h6" marginBlockEnd={1} component="h6">
-				{__('Thanks for letting us know', 'pojo-accessibility')}
+			{isPositiveRating ? <StyledMoodHappy /> : <StyledMoodSad />}
+			<Typography variant="subtitle1" marginBlockEnd={1} marginBlockStart={1}>
+				{isPositiveRating
+					? __("Thanks, that's great to hear!", 'pojo-accessibility')
+					: __('Thanks for letting us know', 'pojo-accessibility')}
 			</Typography>
 			<Typography
 				variant="body1"
@@ -17,9 +23,15 @@ const ThanksForm = () => {
 				marginBlockEnd={3}
 				width="70%"
 			>
-				{__('Help us make Ally even better.', 'pojo-accessibility')}
-				<br />
-				{__('Open to a quick call?', 'pojo-accessibility')}
+				{isPositiveRating
+					? __(
+							'Help us make Ally even better. Open to a quick call?',
+							'pojo-accessibility',
+						)
+					: __(
+							'We regularly chat with Ally users to learn and improve. Open to a quick call?',
+							'pojo-accessibility',
+						)}
 			</Typography>
 		</StyledFormControl>
 	);
@@ -35,6 +47,13 @@ const StyledFormControl = styled(FormControl)`
 `;
 
 const StyledMoodHappy = styled(MoodHappy)`
+	padding: ${({ theme }) => theme.spacing(1.5)};
+	background-color: #f3f3f4;
+	border-radius: ${({ theme }) => theme.spacing(2)};
+	font-size: 24px;
+`;
+
+const StyledMoodSad = styled(MoodSad)`
 	padding: ${({ theme }) => theme.spacing(1.5)};
 	background-color: #f3f3f4;
 	border-radius: ${({ theme }) => theme.spacing(2)};

--- a/modules/reviews/assets/src/components/thanks-form.js
+++ b/modules/reviews/assets/src/components/thanks-form.js
@@ -12,11 +12,18 @@ const ThanksForm = () => {
 	return (
 		<StyledFormControl fullWidth>
 			{isPositiveRating ? <StyledMoodHappy /> : <StyledMoodSad />}
-			<Typography variant="subtitle1" marginBlockEnd={1} marginBlockStart={1}>
+
+			<Typography
+				variant="subtitle1"
+				component="h2"
+				marginBlockEnd={1}
+				marginBlockStart={1}
+			>
 				{isPositiveRating
 					? __("Thanks, that's great to hear!", 'pojo-accessibility')
 					: __('Thanks for letting us know', 'pojo-accessibility')}
 			</Typography>
+
 			<Typography
 				variant="body1"
 				color="secondary"

--- a/modules/reviews/assets/src/components/thanks-form.js
+++ b/modules/reviews/assets/src/components/thanks-form.js
@@ -1,0 +1,42 @@
+import FormControl from '@elementor/ui/FormControl';
+import Typography from '@elementor/ui/Typography';
+import { __ } from '@wordpress/i18n';
+import { MoodHappy } from '../icons';
+
+const ThanksForm = () => {
+	return (
+		<FormControl
+			sx={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 1,
+				textAlign: 'center',
+			}}
+			fullWidth
+		>
+			<MoodHappy
+				sx={{
+					p: 1.5,
+					backgroundColor: '#f3f3f4',
+					borderRadius: 2,
+					fontSize: 24,
+				}}
+			/>
+			<Typography variant="h6" marginBlockEnd={1}>
+				{__('Thanks for letting us know', 'pojo-accessibility')}
+			</Typography>
+			<Typography
+				variant="body1"
+				color="secondary"
+				marginBlockEnd={3}
+				width="70%"
+			>
+				{__('Help us make Ally even better.', 'pojo-accessibility')}
+				<br />
+				{__('Open to a quick call?', 'pojo-accessibility')}
+			</Typography>
+		</FormControl>
+	);
+};
+
+export default ThanksForm;

--- a/modules/reviews/assets/src/constants.js
+++ b/modules/reviews/assets/src/constants.js
@@ -3,3 +3,9 @@ export const WORDPRESS_REVIEW_LINK =
 
 export const SCHEDULING_LINK =
 	'https://calendly.com/d/ctsm-7rx-3nc/ally-user-feedback-call';
+
+export const PAGE_IDS = {
+	RATINGS: 'ratings',
+	FEEDBACK: 'feedback',
+	THANKS: 'thanks',
+};

--- a/modules/reviews/assets/src/constants.js
+++ b/modules/reviews/assets/src/constants.js
@@ -1,2 +1,5 @@
 export const WORDPRESS_REVIEW_LINK =
 	'https://wordpress.org/support/plugin/pojo-accessibility/reviews/#new-post';
+
+export const SCHEDULING_LINK =
+	'https://calendly.com/d/ctsm-7rx-3nc/ally-user-feedback-call';

--- a/modules/reviews/assets/src/constants.js
+++ b/modules/reviews/assets/src/constants.js
@@ -4,8 +4,8 @@ export const WORDPRESS_REVIEW_LINK =
 export const SCHEDULING_LINK =
 	'https://calendly.com/d/ctsm-7rx-3nc/ally-user-feedback-call';
 
-export const PAGE_IDS = {
+export const PAGE_IDS = Object.freeze({
 	RATINGS: 'ratings',
 	FEEDBACK: 'feedback',
 	THANKS: 'thanks',
-};
+});

--- a/modules/reviews/assets/src/hooks/use-settings.js
+++ b/modules/reviews/assets/src/hooks/use-settings.js
@@ -4,6 +4,7 @@ import { useState, createContext, useContext } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __ } from '@wordpress/i18n';
 import APIReview from '../api';
+import { PAGE_IDS } from '../constants';
 
 /**
  * Context Component.
@@ -17,7 +18,7 @@ export function useSettings() {
 const SettingsProvider = ({ children }) => {
 	const [rating, setRating] = useState(0);
 	const [feedback, setFeedback] = useState('');
-	const [currentPage, setCurrentPage] = useState('ratings');
+	const [currentPage, setCurrentPage] = useState(PAGE_IDS.RATINGS);
 	const [isOpened, setIsOpened] = useState(true);
 	const { save, get } = useStorage();
 

--- a/modules/reviews/assets/src/hooks/use-settings.js
+++ b/modules/reviews/assets/src/hooks/use-settings.js
@@ -87,17 +87,19 @@ const SettingsProvider = ({ children }) => {
 				});
 			}
 
-			if (!response?.success && parseInt(ratingToSubmit) < 4) {
-				/**
-				 * Show success message if the feedback was already submitted.
-				 */
-				successNotification(
-					__('Feedback already submitted', 'pojo-accessibility'),
-				);
-			} else if (response?.success && parseInt(ratingToSubmit) < 4) {
-				successNotification(
-					__('Thank you for your feedback!', 'pojo-accessibility'),
-				);
+			if (!avoidClosing) {
+				if (!response?.success && parseInt(ratingToSubmit) < 4) {
+					/**
+					 * Show success message if the feedback was already submitted.
+					 */
+					successNotification(
+						__('Feedback already submitted', 'pojo-accessibility'),
+					);
+				} else if (response?.success && parseInt(ratingToSubmit) < 4) {
+					successNotification(
+						__('Thank you for your feedback!', 'pojo-accessibility'),
+					);
+				}
 			}
 
 			if (!avoidClosing) {

--- a/modules/reviews/assets/src/layouts/user-feedback-form.js
+++ b/modules/reviews/assets/src/layouts/user-feedback-form.js
@@ -9,6 +9,7 @@ import DismissButton from '../components/dismiss-button';
 import FeedbackForm from '../components/feedback-form';
 import RatingForm from '../components/rating-form';
 import ThanksForm from '../components/thanks-form';
+import { PAGE_IDS } from '../constants';
 import { useSettings } from '../hooks/use-settings';
 
 const UserFeedbackForm = () => {
@@ -30,7 +31,7 @@ const UserFeedbackForm = () => {
 		}
 
 		setRating(reviewData.rating);
-		setCurrentPage('thanks');
+		setCurrentPage(PAGE_IDS.THANKS);
 	}, [setCurrentPage, setRating]);
 
 	useEffect(() => {
@@ -47,9 +48,12 @@ const UserFeedbackForm = () => {
 	const anchorPositionOffset = 10;
 
 	const headerMessage = {
-		ratings: __('How would you rate Ally so far?', 'pojo-accessibility'),
-		feedback: __('What could we do better?', 'pojo-accessibility'),
-		thanks: null,
+		[PAGE_IDS.RATINGS]: __(
+			'How would you rate Ally so far?',
+			'pojo-accessibility',
+		),
+		[PAGE_IDS.FEEDBACK]: __('What could we do better?', 'pojo-accessibility'),
+		[PAGE_IDS.THANKS]: null,
 	};
 
 	return (
@@ -97,9 +101,9 @@ const UserFeedbackForm = () => {
 						{headerMessage?.[currentPage]}
 					</Typography>
 				</Header>
-				{'ratings' === currentPage && <RatingForm />}
-				{'feedback' === currentPage && <FeedbackForm />}
-				{'thanks' === currentPage && <ThanksForm />}
+				{PAGE_IDS.RATINGS === currentPage && <RatingForm />}
+				{PAGE_IDS.FEEDBACK === currentPage && <FeedbackForm />}
+				{PAGE_IDS.THANKS === currentPage && <ThanksForm />}
 			</StyledBox>
 			<Footer currentPage={currentPage}>
 				<DismissButton
@@ -135,6 +139,6 @@ const Footer = styled(Box, {
 	justify-content: space-between;
 	align-items: center;
 	${({ currentPage, theme }) =>
-		currentPage !== 'feedback' &&
+		currentPage !== PAGE_IDS.FEEDBACK &&
 		`border-block-start: 1px solid ${theme.palette.divider};`}
 `;

--- a/modules/reviews/assets/src/layouts/user-feedback-form.js
+++ b/modules/reviews/assets/src/layouts/user-feedback-form.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 import DismissButton from '../components/dismiss-button';
 import FeedbackForm from '../components/feedback-form';
 import RatingForm from '../components/rating-form';
-import ReviewForm from '../components/review-form';
+import ThanksForm from '../components/thanks-form';
 import { useSettings } from '../hooks/use-settings';
 
 const UserFeedbackForm = () => {
@@ -23,17 +23,15 @@ const UserFeedbackForm = () => {
 	} = useSettings();
 
 	useEffect(() => {
-		/**
-		 * Show the popover if the user has not submitted repo feedback.
-		 */
-		if (
-			window?.ea11yReviewData?.reviewData?.rating > 3 &&
-			!window?.ea11yReviewData?.reviewData?.repo_review_clicked
-		) {
-			setCurrentPage('review');
-			setRating(window?.ea11yReviewData?.reviewData?.rating); // re-add the saved rating
+		const reviewData = window?.ea11yReviewData?.reviewData;
+
+		if (!reviewData?.submitted || reviewData?.repo_review_clicked) {
+			return;
 		}
-	}, []);
+
+		setRating(reviewData.rating);
+		setCurrentPage('thanks');
+	}, [setCurrentPage, setRating]);
 
 	useEffect(() => {
 		if (isOpened) {
@@ -50,11 +48,8 @@ const UserFeedbackForm = () => {
 
 	const headerMessage = {
 		ratings: __('How would you rate Ally so far?', 'pojo-accessibility'),
-		feedback: __(
-			'We’re thrilled to hear that! What would make it even better?',
-			'pojo-accessibility',
-		),
-		review: null,
+		feedback: __('What could we do better?', 'pojo-accessibility'),
+		thanks: null,
 	};
 
 	return (
@@ -104,7 +99,7 @@ const UserFeedbackForm = () => {
 				</Header>
 				{'ratings' === currentPage && <RatingForm />}
 				{'feedback' === currentPage && <FeedbackForm />}
-				{'review' === currentPage && <ReviewForm />}
+				{'thanks' === currentPage && <ThanksForm />}
 			</StyledBox>
 			<Footer currentPage={currentPage}>
 				<DismissButton

--- a/modules/reviews/module.php
+++ b/modules/reviews/module.php
@@ -177,13 +177,8 @@ class Module extends Module_Base {
 
 			$review_data = $this->get_review_data();
 
-			// Don't show if user has already submitted feedback when rating is less than 4.
-			if ( isset( $review_data['rating'] ) && (int) $review_data['rating'] < 4 ) {
-				return false;
-			}
-
-			// Hide if rating is submitted but repo review is not clicked.
-			if ( (int) $review_data['rating'] > 3 && $review_data['repo_review_clicked'] ) {
+			// Hide once the user has completed the call scheduling prompt.
+			if ( ! empty( $review_data['repo_review_clicked'] ) ) {
 				return false;
 			}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Redesigning review flow to show "thanks" page with call scheduling option after positive ratings, replacing the old redirect-to-review-page behavior. Decouples submission logic from immediate closure.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `mixpanel-events.js` | Added two new events: `callPromptDismissed`, `callScheduleClicked` |
| `dismiss-button.js` | Refactored to handle three page states; added handlers for scheduling/feedback flows; styled layout conditionally |
| `rating-form.js` | Routes low ratings to feedback page; high ratings to thanks page using `PAGE_IDS` constants |
| `thanks-form.js` | New component displaying conditional messaging + mood icons; prompts for scheduling call |
| `constants.js` | Added `PAGE_IDS` enum and `SCHEDULING_LINK` to Calendly |
| `use-settings.js` | Moved initial state to `PAGE_IDS.RATINGS`; wrapped feedback notifications in `!avoidClosing` guard |
| `user-feedback-form.js` | Replaced `review-form` with `thanks-form`; changed logic to show thanks when previously submitted data exists; uses `PAGE_IDS` throughout |
| `module.php` | Simplified condition: only hides popup if `repo_review_clicked` is set (scheduling completed) |

## 3. How It Works

Flow: ratings → (low rating) feedback + submit → thanks, or (high rating) → thanks directly. Thanks page offers "maybe later" (dismisses, logs event) or "pick a time" (opens Calendly, sets flag). Flag prevents popup re-showing. All page transitions use `PAGE_IDS` enum. Feedback submission now only triggers notifications when `!avoidClosing` to avoid messaging during state transitions.

## 4. Risks

Minor: `handleSubmit` now called twice in feedback path (once in `handleNotNowOnFeedback`, once in `handleFeedbackSubmit`), potential for duplicate tracking. Mitigate: verify `handleSubmit` is idempotent or deduplicate client-side. `repo_review_clicked` flag persists indefinitely—no expiry or reset mechanism if user wants to reschedule later.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
