### PR TITLE
Add new user to GitHub deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    if: ( github.actor == 'KingYes' || github.actor == 'bainternet'  || github.actor == 'arielk' || github.actor == 'aviranLevi1' ) && startsWith( github.repository, 'elementor/' )
+    if: ( github.actor == 'KingYes' || github.actor == 'bainternet' || github.actor == 'arielk' || github.actor == 'rami-elementor' ) && startsWith( github.repository, 'elementor/' )
     uses: ./.github/workflows/build.yml
     secrets: inherit
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Updating GitHub Actions deploy permissions to swap out a user (`aviranLevi1`) for a new one (`rami-elementor`), likely due to team changes or access policy updates.

## 2. What Changed (Where)

`.github/workflows/deploy.yml`: Modified the `build` job's conditional to replace `aviranLevi1` with `rami-elementor` in the allowed actors list.

## 3. How It Works

The `if` condition gates job execution to four whitelisted GitHub users on the `elementor/` repository. No logic changes—purely roster update.

## 4. Risks

New user (`rami-elementor`) now has deploy permissions; verify this account exists and is intended. Removed user (`aviranLevi1`) loses deploy access; confirm offboarding is intentional.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
