### PR TITLE
[APP-2954] AI fix not work

### DIFF
--- a/modules/remediation/assets/js/module.js
+++ b/modules/remediation/assets/js/module.js
@@ -116,6 +116,10 @@ if (
 		}
 	}
 
+	// Expose so external callers (e.g. the scanner after DOM normalization)
+	// can re-run pending remediations against the updated DOM.
+	window.AllyRemediations.initialize = initializeRemediations;
+
 	// Run on DOMContentLoaded with timeout
 	window.addEventListener('DOMContentLoaded', function () {
 		setTimeout(() => {

--- a/modules/remediation/components/remediation-runner.php
+++ b/modules/remediation/components/remediation-runner.php
@@ -218,6 +218,10 @@ class Remediation_Runner {
 	}
 
 	public function run_remediations( $buffer ): string {
+		if ( ! $buffer ) {
+			return $buffer;
+		}
+
 		$is_params_empty = empty( $_POST ) && empty( $_GET );
 		$is_cacheable = ! is_user_logged_in() && ! $this->is_woocommerce_dynamic_page();
 

--- a/modules/remediation/module.php
+++ b/modules/remediation/module.php
@@ -3,11 +3,12 @@
 namespace EA11y\Modules\Remediation;
 
 use EA11y\Classes\Module_Base;
+use EA11y\Classes\Utils;
 use EA11y\Modules\Connect\Module as Connect;
+use EA11y\Modules\Legacy\Module as LegacyModule;
 use EA11y\Modules\Remediation\Database\Global_Remediation_Relationship_Table;
 use EA11y\Modules\Remediation\Database\Page_Table;
 use EA11y\Modules\Remediation\Database\Remediation_Table;
-use EA11y\Modules\Legacy\Module as LegacyModule;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -24,7 +25,7 @@ class Module extends Module_Base {
 		if ( LegacyModule::is_active() ) {
 			return false;
 		}
-		
+
 		return Connect::is_connected();
 	}
 
@@ -57,9 +58,23 @@ class Module extends Module_Base {
 		Global_Remediation_Relationship_Table::install();
 	}
 
+	/**
+	 * Enqueue Scripts
+	 */
+	public function enqueue_assets() : void {
+		if ( is_admin() ) {
+			return;
+		}
+
+		Utils\Assets::enqueue_app_assets( 'remediation-module', false );
+	}
+
 	public function __construct() {
 		$this->run_migrations();
 		$this->register_routes();
 		$this->register_components();
+
+		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+
 	}
 }

--- a/modules/scanner/assets/js/hooks/scanner-context/useScannerWizardEffects.js
+++ b/modules/scanner/assets/js/hooks/scanner-context/useScannerWizardEffects.js
@@ -5,6 +5,10 @@ import {
 	removeExistingFocus,
 } from '@ea11y-apps/scanner/utils/focus-on-element';
 import { getElementByXPath } from '@ea11y-apps/scanner/utils/get-element-by-xpath';
+import {
+	fetchPublicDocument,
+	normalizeToPublicDom,
+} from '@ea11y-apps/scanner/utils/public-dom-normalizer';
 import { useEffect } from '@wordpress/element';
 
 export default function useScannerWizardEffects(state, actions) {
@@ -67,16 +71,25 @@ export default function useScannerWizardEffects(state, actions) {
 	// initial load and scannerWizard logic
 	useEffect(() => {
 		if (window.ea11yScannerData?.isConnected) {
-			setTimeout(() => {
-				scannerWizard
-					.load()
-					.then(() => {
-						void actions.getResults();
-					})
-					.catch(() => {
-						setIsError(true);
-						setLoading(false);
-					});
+			setTimeout(async () => {
+				try {
+					const publicDoc = await fetchPublicDocument(
+						window.ea11yScannerData?.pageData?.url,
+					);
+					if (publicDoc) {
+						normalizeToPublicDom(publicDoc);
+					}
+
+					// Re-run remediations against the normalized DOM so
+					// fixes are reflected before the scanner inspects it.
+					window.AllyRemediations?.initialize?.();
+
+					await scannerWizard.load();
+					void actions.getResults();
+				} catch {
+					setIsError(true);
+					setLoading(false);
+				}
 			}, 500);
 			void actions.updateRemediationList();
 		} else {

--- a/modules/scanner/assets/js/utils/close-widget.js
+++ b/modules/scanner/assets/js/utils/close-widget.js
@@ -1,4 +1,9 @@
 import { removeExistingFocus } from '@ea11y-apps/scanner/utils/focus-on-element';
+import {
+	clearRemovedNodes,
+	getRemovedNodes,
+	restorePublicDomChanges,
+} from '@ea11y-apps/scanner/utils/public-dom-normalizer';
 
 export const closeWidget = (widget) => {
 	removeExistingFocus();
@@ -9,5 +14,7 @@ export const closeWidget = (widget) => {
 	url.searchParams.delete('open-ea11y-assistant-src');
 	document.body.style.removeProperty('margin-inline-end');
 	document.body.prepend(window.ea11yScannerData.adminBar);
+	restorePublicDomChanges(getRemovedNodes());
+	clearRemovedNodes();
 	window.history.replaceState({}, '', url.toString());
 };

--- a/modules/scanner/assets/js/utils/public-dom-normalizer.js
+++ b/modules/scanner/assets/js/utils/public-dom-normalizer.js
@@ -1,0 +1,141 @@
+import { ROOT_ID } from '@ea11y-apps/scanner/constants';
+
+let removedNodes = [];
+
+/**
+ * Builds a stable signature for a top-level child node.
+ *
+ * @param {Element} el
+ */
+const buildSignature = (el) => {
+	if (!el || el.nodeType !== Node.ELEMENT_NODE) {
+		return '';
+	}
+
+	const tag = el.tagName.toLowerCase();
+	const id = el.id ? `#${el.id}` : '';
+
+	const unstableClassRegex =
+		/^(wp-|is-|has-|hover|active|focus|elementor-edit-mode|menu-item-\d+)/;
+	const stableClass = Array.from(el.classList).find(
+		(c) => !unstableClassRegex.test(c),
+	);
+	const cls = stableClass ? `.${stableClass}` : '';
+
+	const dataAttrs = Array.from(el.attributes)
+		.filter((a) => a.name.startsWith('data-'))
+		.map((a) => a.name)
+		.sort()
+		.join(',');
+	const data = dataAttrs ? `@${dataAttrs}` : '';
+
+	return `${tag}${id}${cls}${data}`;
+};
+
+/**
+ * Fetch the same URL as an anonymous visitor and return a parsed Document.
+ *
+ * @param {string} url
+ */
+export const fetchPublicDocument = async (url) => {
+	if (!url) {
+		return null;
+	}
+
+	try {
+		const response = await fetch(url, {
+			credentials: 'omit',
+			cache: 'no-store',
+			headers: { 'X-EA11y-Public-Scan': '1' },
+		});
+
+		if (!response.ok) {
+			console.warn(
+				`[ea11y] public-DOM fetch failed: ${response.status} ${response.statusText}`,
+			);
+			return null;
+		}
+
+		const contentType = response.headers.get('content-type') || '';
+		if (!contentType.includes('html')) {
+			console.warn(
+				`[ea11y] public-DOM fetch returned non-html content-type: ${contentType}`,
+			);
+			return null;
+		}
+
+		const text = await response.text();
+		return new DOMParser().parseFromString(text, 'text/html');
+	} catch (e) {
+		console.warn('[ea11y] public-DOM fetch threw', e);
+		return null;
+	}
+};
+
+/**
+ * Removes admin-only top-level children of <body> that don't appear in the
+ * public document.
+ *
+ * @param {Document} publicDoc
+ */
+export const normalizeToPublicDom = (publicDoc) => {
+	if (!publicDoc || !publicDoc.body || !document.body) {
+		return [];
+	}
+
+	const publicSignatures = new Set(
+		Array.from(publicDoc.body.children).map(buildSignature),
+	);
+
+	const captured = [];
+	const liveChildren = Array.from(document.body.children);
+
+	for (const child of liveChildren) {
+		if (child.id === ROOT_ID) {
+			continue;
+		}
+
+		const sig = buildSignature(child);
+		if (sig && publicSignatures.has(sig)) {
+			continue;
+		}
+
+		captured.push({
+			node: child,
+			parent: document.body,
+			nextSibling: child.nextSibling,
+		});
+	}
+
+	for (const entry of captured) {
+		entry.node.remove();
+	}
+
+	removedNodes = removedNodes.concat(captured);
+	return captured;
+};
+
+/**
+ * Re-inserts previously-removed nodes at their original positions.
+ *
+ * @param {Array<{node: Element, parent: Element, nextSibling: Node|null}>} entries
+ */
+export const restorePublicDomChanges = (entries = removedNodes) => {
+	for (const { node, parent, nextSibling } of entries) {
+		if (!parent || !parent.isConnected) {
+			continue;
+		}
+
+		if (nextSibling && nextSibling.parentNode === parent) {
+			parent.insertBefore(node, nextSibling);
+		} else {
+			parent.appendChild(node);
+		}
+	}
+};
+
+export const getRemovedNodes = () => removedNodes;
+
+export const clearRemovedNodes = () => {
+	removedNodes = [];
+};


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

AI remediations weren't re-running after DOM normalization removes admin-only elements. Fix fetches public DOM, normalizes the live DOM to match it, then reinitializes remediations before scanner inspection.

## 2. What Changed (Where)

- **remediation/assets/js/module.js**: Expose `initializeRemediations` to window for external re-triggering
- **scanner/assets/js/useScannerWizardEffects.js**: Fetch public DOM, normalize live DOM, call remediation re-init before scanner load
- **scanner/assets/js/utils/public-dom-normalizer.js**: New utility tracking/restoring removed admin nodes with stable signatures
- **scanner/assets/js/close-widget.js**: Restore removed nodes when closing scanner widget
- **remediation/components/remediation-runner.php**: Guard against empty buffer input
- **remediation/module.php**: Enqueue frontend assets, fix import order and whitespace

## 3. How It Works

Entry: Scanner loads → fetches anonymous version of page → compares top-level `<body>` children using stable signatures (tag, id, safe classes, data attrs) → removes admin-only nodes → calls `window.AllyRemediations.initialize()` to rerun fixes on normalized DOM → scanner then inspects clean state. On widget close, restores removed nodes to original positions.

## 4. Risks

**Timing race**: 500ms setTimeout may be insufficient if fetch is slow or DOM-heavy; consider Promise-based coordination. **Signature collision**: Two unrelated elements matching signature could cause wrong node removal—mitigated by filtering wp-/is-/has- prefixes but fragile for custom admin markup.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
