### PR TITLE
[APP-2970] Renaming Ally to Web Accessibility

### DIFF
--- a/modules/deactivation/module.php
+++ b/modules/deactivation/module.php
@@ -75,7 +75,7 @@ class Module extends Module_Base {
 		<div id="ea11y-deactivation-modal" class="ea11y-deactivation-modal">
 			<div class="ea11y-deactivation-content">
 				<h4>
-					<?php esc_html_e( 'If you have a moment, please share why you are deactivating Ally:', 'pojo-accessibility' ); ?>
+					<?php esc_html_e( 'If you have a moment, please share why you are deactivating Web Accessibility:', 'pojo-accessibility' ); ?>
 				</h4>
 
 				<div class="ea11y-feedback-options">

--- a/modules/legacy/components/upgrade.php
+++ b/modules/legacy/components/upgrade.php
@@ -196,7 +196,7 @@ class Upgrade {
 						></iframe>
 					</div>
 					<h2 class="intro-title"><?php esc_html_e( 'Switch to our new accessibility widget', 'pojo-accessibility' ); ?></h2>
-					<p class="intro-description typography-body1"><?php esc_html_e( 'Ally - Web Accessibility is our new and improved accessibility plugin. Get advanced customization, control, and customer support with one simple switch.', 'pojo-accessibility' ); ?></p>
+					<p class="intro-description typography-body1"><?php esc_html_e( 'Web Accessibility is our new and improved accessibility plugin. Get advanced customization, control, and customer support with one simple switch.', 'pojo-accessibility' ); ?></p>
 					<div>
 						<ul class="benefits typography-body1">
 							<li>
@@ -211,7 +211,7 @@ class Upgrade {
 					<a class="intro-learn-more no-underline typography-body1" href="<?php echo esc_url( self::get_learn_more_link( 'acc-popup-switch-oc' ) ); ?>"><?php esc_html_e( 'Learn more about the changes', 'pojo-accessibility' ); ?></a>
 					<div class="footer-actions">
 						<a href="#" class="close-button no-underline"><?php esc_html_e( 'Not now', 'pojo-accessibility' ); ?></a>
-						<a href="<?php echo esc_url( self::get_switch_now_link() ); ?>" class="button button-primary switch-now"><?php esc_html_e( 'Switch to Ally', 'pojo-accessibility' ); ?></a>
+						<a href="<?php echo esc_url( self::get_switch_now_link() ); ?>" class="button button-primary switch-now"><?php esc_html_e( 'Switch to Web Accessibility', 'pojo-accessibility' ); ?></a>
 					</div>
 				</div>
 			</div>
@@ -386,8 +386,8 @@ class Upgrade {
 							</svg>
 						</div>
 					</div>
-					<h2 class="confirmation-title"><?php esc_html_e( 'Confirm switching to Ally', 'pojo-accessibility' ); ?></h2>
-					<p class="confirmation-description"><?php esc_html_e( 'You’re about to switch from One click accessibility, which we no longer support, to Ally - Web Accessibility. Any previous settings will be removed, and this action cannot be undone.', 'pojo-accessibility' ); ?></p>
+					<h2 class="confirmation-title"><?php esc_html_e( 'Confirm switching to Web Accessibility', 'pojo-accessibility' ); ?></h2>
+					<p class="confirmation-description"><?php esc_html_e( 'You’re about to switch from One click accessibility, which we no longer support, to Web Accessibility. Any previous settings will be removed, and this action cannot be undone.', 'pojo-accessibility' ); ?></p>
 					<div class="footer-actions">
 						<a href="#" class="close-button no-underline"><?php esc_html_e( 'Keep Current', 'pojo-accessibility' ); ?></a>
 						<a href="<?php echo esc_url( self::get_switch_now_link() ); ?>" class="button button-primary upgrade-now"><?php esc_html_e( 'Confirm and switch', 'pojo-accessibility' ); ?></a>
@@ -592,7 +592,7 @@ class Upgrade {
 		wp_enqueue_style( 'wp-pointer' );
 
 		$pointer_content = '<h3>' . esc_html__( 'Accessibility', 'pojo-accessibility' ) . '</h3>';
-		$pointer_content .= '<p>' . esc_html__( 'Our new, improved accessibility plugin is now available! Ally - Web Accessibility is packed with advanced styling options, improved feature controls, and so much more.', 'pojo-accessibility' ) . '</p>';
+		$pointer_content .= '<p>' . esc_html__( 'Our new, improved accessibility plugin is now available! Web Accessibility is packed with advanced styling options, improved feature controls, and so much more.', 'pojo-accessibility' ) . '</p>';
 
 		$pointer_content .= sprintf(
 			'<p><a class="button button-primary ea11y-pointer-settings-link" href="%s">%s</a></p>',

--- a/modules/legacy/notices/dismissible-deprecated-nag.php
+++ b/modules/legacy/notices/dismissible-deprecated-nag.php
@@ -27,11 +27,11 @@ class Dismissible_Deprecated_Nag extends Notice_Base {
 
 	public function content(): string {
 		return sprintf( '<p>%s <a href="%s">%s</a></p><p><a class="button button-primary" href="%s">%s</a></p>',
-			esc_html__( 'Time to take your site’s accessibility to the next level with Ally - Web Accessibility, our newest plugin packed with advanced widget customization, flexible feature controls, and a built-in statement generator. Want more details before switching?', 'pojo-accessibility' ),
+			esc_html__( 'Time to take your site’s accessibility to the next level with Web Accessibility, our newest plugin packed with advanced widget customization, flexible feature controls, and a built-in statement generator. Want more details before switching?', 'pojo-accessibility' ),
 			esc_attr( Upgrade::get_learn_more_link( 'acc-notice-switch-dash' ) ),
 			esc_html__( 'Learn more', 'pojo-accessibility' ),
 			esc_attr( Upgrade::get_switch_now_link() ),
-			esc_html__( 'Switch To Ally - Web Accessibility', 'pojo-accessibility' )
+			esc_html__( 'Switch To Web Accessibility', 'pojo-accessibility' )
 		);
 	}
 

--- a/modules/legacy/notices/sticky-deprecated-nag.php
+++ b/modules/legacy/notices/sticky-deprecated-nag.php
@@ -22,11 +22,11 @@ class Sticky_Deprecated_Nag extends Notice_Base {
 	public function content(): string {
 		return sprintf( '<h3>%s</h3><p>%s<a href="%s">%s</a></p><p><a class="button button-primary" href="%s">%s</a></p>',
             __( 'New accessibility plugin available!', 'pojo-accessibility' ),
-			__( 'Your current plugin is no longer supported. Switch to Ally - Web Accessibility now to access more customization, control, and tools for a more inclusive site.', 'pojo-accessibility' ),
+			__( 'Your current plugin is no longer supported. Switch to Web Accessibility now to access more customization, control, and tools for a more inclusive site.', 'pojo-accessibility' ),
 			Upgrade::get_learn_more_link( 'acc-notice-switch-oc' ), // link to learn more
 			__( 'Learn More', 'pojo-accessibility' ),
 			Upgrade::get_switch_now_link(), // link to switch now
-			__( 'Switch to Ally', 'pojo-accessibility' )
+			__( 'Switch to Web Accessibility', 'pojo-accessibility' )
 		);
 	}
 

--- a/modules/reviews/assets/src/components/feedback-form.js
+++ b/modules/reviews/assets/src/components/feedback-form.js
@@ -14,7 +14,7 @@ const FeedbackForm = () => {
 				minRows={5}
 				multiline
 				placeholder={__(
-					'Share your thoughts on how we can improve Ally …',
+					'Share your thoughts on how we can improve Web Accessibility …',
 					'pojo-accessibility',
 				)}
 				value={feedback}

--- a/modules/reviews/assets/src/components/review-form.js
+++ b/modules/reviews/assets/src/components/review-form.js
@@ -57,7 +57,10 @@ const ReviewForm = () => {
 				marginBlockEnd={3}
 				width="55%"
 			>
-				{__('Help others discover Ally on WordPress', 'pojo-accessibility')}
+				{__(
+					'Help others discover Web Accessibility on WordPress',
+					'pojo-accessibility',
+				)}
 			</Typography>
 			<Rating
 				emptyIcon={<StarFilledIcon fontSize="large" />}

--- a/modules/reviews/assets/src/components/thanks-form.js
+++ b/modules/reviews/assets/src/components/thanks-form.js
@@ -32,11 +32,11 @@ const ThanksForm = () => {
 			>
 				{isPositiveRating
 					? __(
-							'Help us make Ally even better. Open to a quick call?',
+							'Help us make Web Accessibility even better. Open to a quick call?',
 							'pojo-accessibility',
 						)
 					: __(
-							'We regularly chat with Ally users to learn and improve. Open to a quick call?',
+							'We regularly chat with Web Accessibility users to learn and improve. Open to a quick call?',
 							'pojo-accessibility',
 						)}
 			</Typography>

--- a/modules/reviews/assets/src/layouts/user-feedback-form.js
+++ b/modules/reviews/assets/src/layouts/user-feedback-form.js
@@ -49,7 +49,7 @@ const UserFeedbackForm = () => {
 
 	const headerMessage = {
 		[PAGE_IDS.RATINGS]: __(
-			'How would you rate Ally so far?',
+			'How would you rate Web Accessibility so far?',
 			'pojo-accessibility',
 		),
 		[PAGE_IDS.FEEDBACK]: __('What could we do better?', 'pojo-accessibility'),

--- a/modules/scanner/assets/js/components/block-button/resolve-chip.js
+++ b/modules/scanner/assets/js/components/block-button/resolve-chip.js
@@ -9,7 +9,7 @@ export const ResolveChip = ({ block }) =>
 			size="small"
 			color="info"
 			variant="standard"
-			label={__('Resolve with Ally', 'pojo-accessibility')}
+			label={__('Resolve with Web Accessibility', 'pojo-accessibility')}
 		/>
 	) : (
 		<Chip

--- a/modules/scanner/assets/js/components/manage-item-header/index.js
+++ b/modules/scanner/assets/js/components/manage-item-header/index.js
@@ -39,7 +39,7 @@ export const ManageItemHeader = ({ isActive, openEdit, global }) => {
 					<Tooltip
 						placement="top"
 						title={__(
-							"You can't edit cross-scan fixes with Ally",
+							"You can't edit cross-scan fixes with Web Accessibility",
 							'pojo-accessibility',
 						)}
 						PopperProps={{

--- a/modules/scanner/assets/js/components/not-connected-message/index.js
+++ b/modules/scanner/assets/js/components/not-connected-message/index.js
@@ -19,7 +19,7 @@ export const NotConnectedMessage = () => {
 			</Typography>
 			<ReconnectDescription variant="body2" color="text.secondary">
 				{__(
-					"Check that you're using the right Ally account or reconnect now.",
+					"Check that you're using the right Web Accessibility account or reconnect now.",
 					'pojo-accessibility',
 				)}
 			</ReconnectDescription>

--- a/modules/scanner/assets/js/components/remediation-form/remediation-snippet.js
+++ b/modules/scanner/assets/js/components/remediation-form/remediation-snippet.js
@@ -92,7 +92,7 @@ export const RemediationSnippet = ({ item }) => {
 									<Tooltip
 										placement="top"
 										title={__(
-											"You can't edit cross-scan fixes with Ally",
+											"You can't edit cross-scan fixes with Web Accessibility",
 											'pojo-accessibility',
 										)}
 										PopperProps={{

--- a/modules/scanner/assets/js/components/upgrade-info-tip/upgrade-content.js
+++ b/modules/scanner/assets/js/components/upgrade-info-tip/upgrade-content.js
@@ -87,7 +87,7 @@ export const UpgradeContent = ({
 							'pojo-accessibility',
 						)
 					: __(
-							"Upgrade your plan to skip the manual work and have Ally's AI auto-resolve accessibility issues for you.",
+							"Upgrade your plan to skip the manual work and have Web Accessibility's AI auto-resolve accessibility issues for you.",
 							'pojo-accessibility',
 						)}
 			</Typography>

--- a/modules/scanner/components/list-column.php
+++ b/modules/scanner/components/list-column.php
@@ -31,7 +31,7 @@ class List_Column {
 	}
 
 	public function add_accessibility_column( $columns ) {
-		$columns['accessibility_status'] = '<a class="ea11y-tooltip ea11y-tooltip-n ea11y-tooltip-hidden" data-label="' . esc_attr__( 'Ally', 'pojo-accessibility' ) . '"><img src="' . esc_url( EA11Y_ASSETS_URL . 'images/logo.svg' ) . '" alt="" style="width:20px; height:20px; vertical-align:middle; margin-inline-end:8px;" /></a><span class="ea11y-column-title" title="' . esc_attr__( 'Ally', 'pojo-accessibility' ) . '">' . esc_html__( 'Ally', 'pojo-accessibility' ) . '</span>';
+		$columns['accessibility_status'] = '<a class="ea11y-tooltip ea11y-tooltip-n ea11y-tooltip-hidden" data-label="' . esc_attr__( 'Web Accessibility', 'pojo-accessibility' ) . '"><img src="' . esc_url( EA11Y_ASSETS_URL . 'images/logo.svg' ) . '" alt="" style="width:20px; height:20px; vertical-align:middle; margin-inline-end:8px;" /></a><span class="ea11y-column-title" title="' . esc_attr__( 'Web Accessibility', 'pojo-accessibility' ) . '">' . esc_html__( 'Web Accessibility', 'pojo-accessibility' ) . '</span>';
 		return $columns;
 	}
 

--- a/modules/settings/assets/js/components/analytics/analytics-toggle.js
+++ b/modules/settings/assets/js/components/analytics/analytics-toggle.js
@@ -101,7 +101,7 @@ export const AnalyticsToggle = () => {
 				>
 					<DialogContentText id="confirm-enable-analytics-description">
 						{__(
-							'This allows Ally to record how visitors open and use your accessibility widget, unlocking real‑time analytics.',
+							'This allows Web Accessibility to record how visitors open and use your accessibility widget, unlocking real‑time analytics.',
 							'pojo-accessibility',
 						)}
 					</DialogContentText>

--- a/modules/settings/assets/js/components/connect-modal/index.js
+++ b/modules/settings/assets/js/components/connect-modal/index.js
@@ -80,7 +80,7 @@ const ConnectModal = () => {
 					id="connect-modal-description"
 				>
 					{__(
-						'Make your site more inclusive with Ally - Web Accessibility.',
+						'Make your site more inclusive with Web Accessibility.',
 						'pojo-accessibility',
 					)}
 				</Typography>

--- a/modules/settings/assets/js/components/help-menu/get-started-modal.js
+++ b/modules/settings/assets/js/components/help-menu/get-started-modal.js
@@ -52,7 +52,7 @@ const GetStartedModal = () => {
 
 		mixpanelService
 			.sendEvent(mixpanelEvents.menuButtonClicked, {
-				buttonName: 'Get started with Ally - Modal Closed',
+				buttonName: 'Get started with Web Accessibility - Modal Closed',
 			})
 			.catch((error) => {
 				console.error('Failed to send mixpanel event:', error);
@@ -85,11 +85,11 @@ const GetStartedModal = () => {
 					color="text.primary"
 					marginBlockStart={2}
 				>
-					{__('Getting started with Ally', 'pojo-accessibility')}
+					{__('Getting started with Web Accessibility', 'pojo-accessibility')}
 				</DialogContentText>
 				<DialogContentText variant="body1">
 					{__(
-						'Watch this quick video to see how Ally helps you find, understand, and fix accessibility issues across your site with ease.',
+						'Watch this quick video to see how Web Accessibility helps you find, understand, and fix accessibility issues across your site with ease.',
 						'pojo-accessibility',
 					)}
 				</DialogContentText>

--- a/modules/settings/assets/js/components/help-menu/popup-menu.js
+++ b/modules/settings/assets/js/components/help-menu/popup-menu.js
@@ -14,7 +14,7 @@ export const HelpPopupMenu = ({ closeAction, ...menuProps }) => {
 	const handleGetStartedClick = () => {
 		mixpanelService.sendEvent(mixpanelEvents.popupButtonClicked, {
 			popupType: 'get_started_with_ally',
-			buttonName: 'Get started with Ally',
+			buttonName: 'Get started with Web Accessibility',
 		});
 		setIsGetStartedModalOpen(true);
 
@@ -51,7 +51,7 @@ export const HelpPopupMenu = ({ closeAction, ...menuProps }) => {
 		>
 			<StyledMenuItem dense onClick={handleGetStartedClick}>
 				<StyledTypography>
-					{__('Get started with Ally', 'pojo-accessibility')}
+					{__('Get started with Web Accessibility', 'pojo-accessibility')}
 				</StyledTypography>
 			</StyledMenuItem>
 

--- a/modules/settings/assets/js/components/onboarding-modal/index.js
+++ b/modules/settings/assets/js/components/onboarding-modal/index.js
@@ -60,7 +60,7 @@ const OnboardingModal = () => {
 		>
 			<DialogHeader logo={false} onClose={onClose}>
 				<DialogTitle>
-					{__('Ally Accessibility', 'pojo-accessibility')}
+					{__('Web Accessibility', 'pojo-accessibility')}
 				</DialogTitle>
 			</DialogHeader>
 
@@ -79,7 +79,10 @@ const OnboardingModal = () => {
 					color="text.primary"
 					marginBlockStart={2}
 				>
-					{__('See Ally’s new assistant in action', 'pojo-accessibility')}
+					{__(
+						'See Web Accessibility’s new assistant in action',
+						'pojo-accessibility',
+					)}
 				</DialogContentText>
 				<DialogContentText>
 					{__(

--- a/modules/settings/assets/js/components/post-connect-modal/index.js
+++ b/modules/settings/assets/js/components/post-connect-modal/index.js
@@ -77,7 +77,7 @@ const PostConnectModal = () => {
 					id="post-connect-modal-description"
 				>
 					{__(
-						'Ally - Web Accessibility is now connected and ready to use on your site.',
+						'Web Accessibility is now connected and ready to use on your site.',
 						'pojo-accessibility',
 					)}
 				</Typography>

--- a/modules/settings/assets/js/components/url-mismatch-modal/index.js
+++ b/modules/settings/assets/js/components/url-mismatch-modal/index.js
@@ -77,7 +77,7 @@ const UrlMismatchModal = () => {
 				<StyledGridContainer>
 					<StyledTitle variant="h4">
 						{__(
-							'Choose how to reconnect Ally to your site',
+							'Choose how to reconnect Web Accessibility to your site',
 							'pojo-accessibility',
 						)}
 					</StyledTitle>

--- a/modules/settings/assets/js/layouts/logo-settings.js
+++ b/modules/settings/assets/js/layouts/logo-settings.js
@@ -24,7 +24,7 @@ const LogoSettings = () => {
 			<CardHeader
 				title={
 					<>
-						{__('Ally by Elementor logo', 'pojo-accessibility')}
+						{__('Web Accessibility by Elementor logo', 'pojo-accessibility')}
 						{!isProEnabled() && (
 							<ProItemInfotip
 								childKey={PRO_FEATURES.REMOVE_BRANDING}

--- a/modules/settings/assets/js/pages/assistant/empty-state.js
+++ b/modules/settings/assets/js/pages/assistant/empty-state.js
@@ -80,7 +80,7 @@ const AccessibilityAssistantEmptyState = () => {
 
 						<Typography variant="body2">
 							{__(
-								'Resolve them with Ally, AI, or manually.',
+								'Resolve them with Web Accessibility, AI, or manually.',
 								'pojo-accessibility',
 							)}
 						</Typography>

--- a/modules/settings/banners/onboarding-banner.php
+++ b/modules/settings/banners/onboarding-banner.php
@@ -68,7 +68,7 @@ class Onboarding_Banner {
 				</div>
 					<div class="elementor-ea11y-banner-content-text">
 						<h2>
-							<?php _e( 'New in Ally: Accessibility Assistant', 'pojo-accessibility' ); ?>
+							<?php _e( 'New in Web Accessibility: Accessibility Assistant', 'pojo-accessibility' ); ?>
 						</h2>
 						<p>
 							<?php _e( 'Scan your site for accessibility issues and start fixing them with ease. It\'s already part of your plan.', 'pojo-accessibility' ); ?>

--- a/modules/settings/components/settings-pointer.php
+++ b/modules/settings/components/settings-pointer.php
@@ -34,7 +34,7 @@ class Settings_Pointer {
 		wp_enqueue_style( 'wp-pointer' );
 		wp_enqueue_script( 'wp-util' );
 
-		$pointer_content = '<h3>' . esc_html__( 'Ally - Web Accessibility', 'pojo-accessibility' ) . '</h3>';
+		$pointer_content = '<h3>' . esc_html__( 'Web Accessibility', 'pojo-accessibility' ) . '</h3>';
 		$pointer_content .= '<p>' . esc_html__( "Start setting up and customizing your site's accessibility widget.", 'pojo-accessibility' ) . '</p>';
 
 		$pointer_content .= sprintf(

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -61,7 +61,7 @@ class Module extends Module_Base {
 	public function register_page(): void {
 		add_submenu_page(
 			'elementor-home',
-			__( 'Ally - Web Accessibility', 'pojo-accessibility' ),
+			__( 'Web Accessibility', 'pojo-accessibility' ),
 			__( 'Accessibility', 'pojo-accessibility' ),
 			self::SETTING_CAPABILITY,
 			self::SETTING_BASE_SLUG,

--- a/modules/settings/notices/renewal-notice.php
+++ b/modules/settings/notices/renewal-notice.php
@@ -84,8 +84,8 @@ class Renewal_Notice extends Notice_Base {
 	public function get_renewal_text(): array {
 		if ( $this->days_diff <= 30 && $this->days_diff > 0 ) {
 			return [
-				'title'       => esc_html__( 'Ally Subscription Ending Soon!', 'pojo-accessibility' ),
-				'description' => esc_html__( 'Renew now to keep access to Ally Assistant and continue improving your website\'s accessibility with guided fixes and scans.', 'pojo-accessibility' ),
+				'title'       => esc_html__( 'Web Accessibility Subscription Ending Soon!', 'pojo-accessibility' ),
+				'description' => esc_html__( 'Renew now to keep access to Accessibility Assistant and continue improving your website\'s accessibility with guided fixes and scans.', 'pojo-accessibility' ),
 				'btn'         => esc_html__( 'Enable Auto-Renew', 'pojo-accessibility' ),
 				'link'        => esc_url( SettingsModule::get_upgrade_link( 'acc-renew-30' ) ),
 				'type'        => 'warning',
@@ -93,16 +93,16 @@ class Renewal_Notice extends Notice_Base {
 		}
 		if ( $this->days_diff <= 0 && $this->days_diff > -7 ) {
 			return [
-				'title'       => esc_html__( 'Your Ally subscription has expired', 'pojo-accessibility' ),
-				'description' => esc_html__( 'Ally Assistant is no longer active. Renew now to resume accessibility scans and step by step fixes for your site.', 'pojo-accessibility' ),
+				'title'       => esc_html__( 'Your Web Accessibility subscription has expired', 'pojo-accessibility' ),
+				'description' => esc_html__( 'Accessibility Assistant is no longer active. Renew now to resume accessibility scans and step by step fixes for your site.', 'pojo-accessibility' ),
 				'btn'         => esc_html__( 'Renew Now', 'pojo-accessibility' ),
 				'link'        => esc_url( SettingsModule::get_upgrade_link( 'acc-renew-expire' ) ),
 				'type'        => 'error',
 			];
 		}
 		return [
-			'title'       => esc_html__( "It's not too late - renew Ally", 'pojo-accessibility' ),
-			'description' => esc_html__( "Reactivate your subscription to restore Ally Assistant and continue improving your website's accessibility.", 'pojo-accessibility' ),
+			'title'       => esc_html__( "It's not too late - renew Web Accessibility", 'pojo-accessibility' ),
+			'description' => esc_html__( "Reactivate your subscription to restore Accessibility Assistant and continue improving your website's accessibility.", 'pojo-accessibility' ),
 			'btn'         => esc_html__( 'Reactivate Now', 'pojo-accessibility' ),
 			'link'        => esc_url( SettingsModule::get_upgrade_link( 'acc-renew-post-expire' ) ),
 			'type'        => 'error',

--- a/modules/widget/assets/js/ally-gutenberg-block.js
+++ b/modules/widget/assets/js/ally-gutenberg-block.js
@@ -30,13 +30,13 @@ const Save = ({ attributes }) => {
 
 registerBlockType('ally/custom-link', {
 	apiVersion: 3,
-	title: __('Ally Widget Trigger', 'pojo-accessibility'),
+	title: __('Web Accessibility Widget Trigger', 'pojo-accessibility'),
 	icon: 'admin-links',
 	category: 'widgets',
 	attributes: {
 		linkText: {
 			type: 'string',
-			default: __('Open Ally Widget', 'pojo-accessibility'),
+			default: __('Open Web Accessibility Widget', 'pojo-accessibility'),
 		},
 	},
 	edit: Edit,

--- a/pojo-accessibility.php
+++ b/pojo-accessibility.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Ally - Web Accessibility & Usability
+ * Plugin Name: Web Accessibility - WCAG Scanning, Guided Fixes, Usability Widget
  * Plugin URI: https://elementor.com/
  * Description: Improve your website’s accessibility with ease. Customize capabilities such as text resizing, contrast modes, link highlights, and easily generate an accessibility statement to demonstrate your commitment to inclusivity.
  * Author: Elementor.com
@@ -8,12 +8,12 @@
  * Version: 4.1.2
  * Text Domain: pojo-accessibility
  *
- * Ally is free software: you can redistribute it and/or modify
+ * Web Accessibility is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * any later version.
  *
- * Ally is distributed in the hope that it will be useful,
+ * Web Accessibility is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Ally - Web Accessibility & Usability ===
+=== Web Accessibility (formally known as Ally) - WCAG Scanning, Guided Fixes, Usability Widget ===
 Contributors: elemntor
 Tags: Web Accessibility, Accessibility, A11Y, WCAG, Accessibility Statement
 Requires at least: 6.7
@@ -7,39 +7,38 @@ Requires PHP: 7.4
 Stable tag: 4.1.2
 License: GPLv2 or later
 
-Ally: Make your site more inclusive by scanning for accessibility violations, fixing them easily, and adding a usability widget and accessibility statement.
+Web Accessibility (formally known as Ally) is a free, powerful, and user-friendly plugin that helps WordPress creators build more accessible websites with ease.
 
 == Description ==
 
 https://www.youtube.com/watch?v=-2ig5D348vo
 
-Ally (formerly One Click Accessibility) is a free, powerful, and user-friendly plugin that helps WordPress creators build more accessible websites with ease.
+Web Accessibility (formally known as Ally) is a free, powerful, and user-friendly plugin that helps WordPress creators build more accessible websites with ease.
 It simplifies accessibility with three essential tools:
 
-- **Ally Assistant** – Scan your pages, detect accessibility violations, and follow guided steps to fix them. Make manual adjustments or apply AI-powered suggestions, and track your progress.
+- **Accessibility Assistant** – Scan your pages, detect accessibility violations, and follow guided steps to fix them. Make manual adjustments or apply AI-powered suggestions, and track your progress.
 - **Usability widget** – Let visitors personalize their browsing experience with a floating accessibility menu. Features include font resizing, color contrast, image hiding, animation pausing, language selection, screen reader support, and more.
 - **Accessibility statement generator** – Create a fully customized accessibility statement and publish it automatically on your site, helping meet WCAG and legal requirements.
 
-**No expertise required** -just activate, configure, and start making your site more inclusive today.Built by Elementor. Designed for every WordPress site. Ally is web accessibility—simplified.
-
+**No expertise required** - Just activate, configure, and start making your site more inclusive today. Built by Elementor and designed for every WordPress site.
 
 === Why does web accessibility matter?
-- **Who Needs It?** Every website owner—businesses, creators, and agencies.
-- **Who is Responsible?** Website owners are legally and ethically responsible for accessibility. The web creator—who designs and builds the site—must implement and adjust accessibility features to ensure compliance with WCAG guidelines and provide an inclusive experience for all users.
+- **Who Needs It?** Every website owner, for businesses, creators, and agencies.
+- **Who is Responsible?** Website owners are legally and ethically responsible for accessibility. The web creator who designs and builds the site must implement and adjust accessibility features to ensure compliance with WCAG guidelines and provide an inclusive experience for all users.
 - **Why Now?** Rising legal requirements (WCAG, EAA) and better user experience.
-- **Why Should You Care?**  An accessible website isn't just ethical; it's good business. By prioritizing inclusivity, you improve user experience for everyone, boost your search engine rankings, and attract a wider audience.
+- **Why Should You Care?** An accessible website isn't just ethical; it's good business. By prioritizing inclusivity, you improve user experience for everyone, boost your search engine rankings, and attract a wider audience.
 
-=== It’s the Law
+=== It's the Law
 
-As accessibility standards continue to evolve and become mandatory, it’s important to start making website adjustments to comply with fast-approaching global regulations. Among its other capabilities, this plugin lets you instantly generate your website's Accessibility Statement, which is now mandatory in most locales.
+As accessibility standards continue to evolve and become mandatory, it's important to start making website adjustments to comply with fast-approaching global regulations. Among its other capabilities, this plugin lets you instantly generate your website's Accessibility Statement, which is now mandatory in most locales.
 
-The Ally plugin is not a substitute for a thorough accessibility audit and is NOT intended to completely make your website legally compliant. However, with it, you’re one step closer to making your website inclusive to more visitors, including those with visual, auditory or cognitive challenges.
+The Web Accessibility plugin is not a substitute for a thorough accessibility audit and is NOT intended to completely make your website legally compliant. However, with it, you're one step closer to making your website inclusive to more visitors, including those with visual, auditory, or cognitive challenges.
 
 Ensuring that your website complies with all applicable accessibility requirements is your responsibility. We recommend working with qualified accessibility professionals to help achieve full compliance.
 
 == Key Features & Benefits ==
 
-= Ally Assistant =
+= Accessibility Assistant =
 
 * Scan any URL on demand to detect accessibility gaps
 * Launch directly from WordPress or Elementor
@@ -50,8 +49,7 @@ Ensuring that your website complies with all applicable accessibility requiremen
 
 = How It Works =
 
-Ally Assistant scans individual URLs for accessibility violations, categorizes them by type and severity, and provides actionable insights. You can apply manual fixes manually or use AI suggestions while tracking your progress over time.
-Ally Assistant helps you:
+Accessibility Assistant scans individual URLs for accessibility violations, categorizes them by type and severity, and provides actionable insights. You can apply manual fixes manually or use AI suggestions while tracking your progress over time. Accessibility Assistant helps you:
 
 * Detect missing alternative text
 * Label dynamic content & ARIA landmarks
@@ -63,7 +61,7 @@ Ally Assistant helps you:
 * And detect 180+ other common accessibility violations based on WCAG 2.1 AA
 
 = Accessibility Statement Generator =
-* Auto-generate a complete  accessibility statement
+* Auto-generate a complete accessibility statement
 * Customize and publish to a dedicated page
 * Link it using the widget
 
@@ -87,9 +85,8 @@ Premium widget features are also available within paid plans, including:
 * Language selector directly in the widget
 * Usage analytics to gain actionable insights from visitor interactions
 
-
 = Widget customization options for web creators =
-Tailor the widget’s look and behavior with options like:
+Tailor the widget's look and behavior with options like:
 
 * Show/hide widget icon on mobile or desktop
 * Select icon type and size
@@ -100,15 +97,15 @@ Tailor the widget’s look and behavior with options like:
 
 
 === Get Started Today ===
-== Make your site more accessible with Ally! ==
-Need help? Visit our [help center](https://go.elementor.com/acc-wp-repo-learn-more) or [contact Supoprt](https://go.elementor.com/wp-repo-wp-dash-sm-contact-us/).
+== Create a better user experience for all with Web Accessibility ==
+Need help? Visit our [help center](https://go.elementor.com/acc-wp-repo-learn-more) or [contact Support](https://go.elementor.com/wp-repo-wp-dash-sm-contact-us/).
 
-This plugin requires a connection to an active Elementor account in order to identify the user and provide the user with the purchased service. This connection is initiated manually by the user via the plugin’s settings panel. Learn more about our [terms and conditions](https://go.elementor.com/acc-wp-repo-term-and-conditions). This plugin uses a 3rd party service operated by Elementor.
+This plugin requires a connection to an active Elementor account to identify the user and provide the purchased service. This connection is initiated manually by the user via the plugin's settings panel. Learn more about our [terms and conditions](https://go.elementor.com/acc-wp-repo-term-and-conditions). This plugin uses a 3rd party service operated by Elementor.
 
 More accessibility features are on the way, so stay tuned!
 
 == Related Plugins ==
-* [Site Mailer](https://wordpress.org/plugins/site-mailer/): Manage transactional emails with ease with Site Mailer. High deliverability, detailed logs and statistics, and no SMTP plugins needed.
+* [Email Deliverability](https://wordpress.org/plugins/site-mailer/): Manage transactional emails with ease. High deliverability, detailed logs and statistics, and no SMTP plugins needed.
 * [Image Optimizer](https://wordpress.org/plugins/image-optimization/): Compress and optimize your images, giving you leaner, faster websites. Automatically optimize any new image you upload or run a bulk optimization process for existing uploads.
 
 
@@ -130,51 +127,50 @@ More accessibility features are on the way, so stay tuned!
 
 == Frequently Asked Questions ==
 
-= What is the Ally plugin? =
+= What is the Web Accessibility plugin? =
 
-Ally is an accessibility plugin for WordPress websites. It helps web creators build more inclusive websites using a customizable widget, on-demand accessibility scans, AI-powered issue remediation, and a centralized dashboard to track progress.
+Web Accessibility is an accessibility plugin for WordPress websites. It helps web creators build more inclusive websites using a customizable widget, on-demand accessibility scans, AI-powered issue remediation, and a centralized dashboard to track progress.
 
-= Who is Ally for? =
+= Who is Web Accessibility for? =
 
-Ally is ideal for freelancers, agencies, and DIY website owners who want to improve accessibility and align with WCAG standards
+Web Accessibility is ideal for freelancers, agencies, and DIY website owners who want to improve accessibility and align with WCAG standards
 
-= Is Ally GDPR compliant? =
+= Is Web Accessibility GDPR compliant? =
 
-Yes, Ally is GDPR compliant. To meet your privacy obligations, you must list Elementor as a sub-processor in your privacy notice. Our [Data Processing Agreement (DPA)](https://elementor.com/terms/plugins-dpa) outlines all privacy-related requirements.
+Yes, Web Accessibility is GDPR compliant. To meet your privacy obligations, you must list Elementor as a sub-processor in your privacy notice. Our [Data Processing Agreement (DPA)](https://elementor.com/terms/plugins-dpa) outlines all privacy-related requirements.
 
-= Can Ally guarantee that my site is fully accessible? =
+= Can Web Accessibility guarantee that my site is fully accessible? =
 
-No automated tool can promise full accessibility. Ally helps you detect and fix the most common violations, but achieving full compliance requires human testing and judgment. Think of Ally as a powerful assistant-not a complete substitute for manual review.
+No automated tool can promise full accessibility. Web Accessibility helps you detect and fix the most common violations, but achieving full compliance requires human testing and judgment. Think of Web Accessibility as a powerful assistant-not a complete substitute for manual review.
 
 = What is an accessibility statement, and how do I create one? =
 
-An accessibility statement is a public declaration of your commitment to inclusive digital experiences. Ally helps you easily generate and publish one as a dedicated page on your website.
+An accessibility statement is a public declaration of your commitment to inclusive digital experiences. Web Accessibility helps you easily generate and publish one as a dedicated page on your website.
 
-= Why do I need an Elementor account to use Ally? =
+= Why do I need an Elementor account to use Web Accessibility? =
 
-An Elementor account lets you manage your Ally settings, track usage, and unlock advanced features like the Assistant and AI fixes.
+An Elementor account lets you manage your Web Accessibility settings, track usage, and unlock advanced features like the Assistant and AI fixes.
 
-= Can I customize the widget’s appearance? =
+= Can I customize the widget's appearance? =
 
-Yes. You can personalize the widget’s icon, colors, size, position, and which features are shown on mobile or desktop.
+Yes. You can personalize the widget's icon, colors, size, position, and which features are shown on mobile or desktop.
 
 = Can visitors hide the widget? =
-Yes. Visitors can choose to temporarily dismiss the widget-for a session, 24 hours, or one week.
+Yes. Visitors can choose to temporarily dismiss the widget for a session, 24 hours, or one week.
 
 = Does the widget support multiple languages? =
-Yes, it automatically adjusts to your site’s language settings.
+Yes, it automatically adjusts to your site's language settings.
 
 
 = What is the Accessibility Assistant? =
 The Accessibility Assistant is a tool that scans individual URLs for accessibility violations, organizes them into categories, and guides you to fix them manually or with AI suggestions
-
 
 = Can I scan the same URL more than once? =
 Yes. You can rescan a URL as often as needed. Results update each time based on the current version of your content.
 
 
 = What are AI fixes? =
-These are smart suggestions generated by Ally to help you resolve issues more efficiently-like automatically suggesting alternative text for images. AI fixes are available only on paid plans and use credits.
+These are smart suggestions generated by Web Accessibility to help you resolve issues more efficiently-like automatically suggesting alternative text for images. AI fixes are available only on paid plans and use credits.
 
 = How can I report security bugs? =
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability](https://patchstack.com/database/wordpress/plugin/pojo-accessibility/vdp).
@@ -188,7 +184,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 4. Accessibility Assistant: Scan any page to instantly detect over 180 common accessibility issues and get clear, guided steps for remediation inside your site editor.
 5. Scan results: View issues highlighted in context and grouped by type such as alt text, ARIA, page structure, and more. Expand any item for step-by-step guidance and optional AI-powered suggestions.
 6. Color contrast: Fine tune text and background colors with live checks that validate contrast ratios.
-7. Scanner dashboard: Track your site’s accessibility scans, monitor open issues, and follow progress over time.
+7. Scanner dashboard: Track your site's accessibility scans, monitor open issues, and follow progress over time.
 
 == Changelog ==
 = 4.1.2 – 2026-06-01 =
@@ -340,10 +336,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 * Fix: Fixed favicon missing on some sites
 
 = 3.0.0  2025-02-18 =
-* 🚀 Introducing Ally Web Accessibility! One Click Accessibility is now Ally Web Accessibility! Discover the new experience: Learn More.
+* Introducing Ally Web Accessibility! One Click Accessibility is now Ally Web Accessibility! Discover the new experience: Learn More.
 * New: Brand-New Interface – Redesigned for seamless touch-screen and mobile support.
 * New: Revamped Infrastructure – Overhauled backend to support new and future capabilities.
-* New: Page Structure Overview – Navigate your page’s structure for better accessibility.
+* New: Page Structure Overview – Navigate your page's structure for better accessibility.
 * New: Image Hiding Option – Hides all images on the page to reduce distractions and make the page more readable.
 * New: Pause animations option – Stops animations running on the page option, helping users focus on content.
 * New: Reading Mask option- helps users focus on specific text, reducing distractions and improving readability.


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Rebranding from "Ally" to "Web Accessibility" across UI strings and user-facing copy (APP-2970). No functional changes—purely textual updates to plugin name, labels, and descriptions.

## 2. What Changed (Where)

| Component | Change |
|-----------|--------|
| Frontend UI (Reviews, Scanner, Settings modules) | 30+ user-facing strings: "Ally" → "Web Accessibility" |
| Plugin header (pojo-accessibility.php) | Plugin name & GPL license header text |
| Modals & Notices | Dialog titles, descriptions, onboarding copy |
| Admin columns & pointers | Tooltip labels and settings page branding |

## 3. How It Works

Straightforward string replacement—no logic changes. All updates use existing `__()` translation function, preserving i18n infrastructure. Text domain remains "pojo-accessibility" throughout.

## 4. Risks

None material. String updates are isolated to display layer; no database migrations, API changes, or behavioral logic affected. Existing translations will need updates but fallback to English gracefully.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
