### PR TITLE
[APP-2954] fix dom normalize fn

### DIFF
--- a/modules/scanner/assets/js/utils/public-dom-normalizer.js
+++ b/modules/scanner/assets/js/utils/public-dom-normalizer.js
@@ -87,11 +87,24 @@ export const normalizeToPublicDom = (publicDoc) => {
 		Array.from(publicDoc.body.children).map(buildSignature),
 	);
 
+	const nonMarkupTags = new Set([
+		'style',
+		'script',
+		'link',
+		'noscript',
+		'meta',
+		'template',
+	]);
+
 	const captured = [];
 	const liveChildren = Array.from(document.body.children);
 
 	for (const child of liveChildren) {
 		if (child.id === ROOT_ID) {
+			continue;
+		}
+
+		if (nonMarkupTags.has(child.tagName.toLowerCase())) {
 			continue;
 		}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Fixes APP-2954 by filtering non-markup tags during DOM normalization to prevent capturing style/script/meta/link elements that shouldn't be considered as content children.

## 2. What Changed (Where)
- `public-dom-normalizer.js`: Added `nonMarkupTags` Set and conditional skip logic in the child iteration loop.

## 3. How It Works
Before capturing DOM children, the normalizer now checks if a child's tag is in the exclusion list (style, script, link, noscript, meta, template) and skips it, preventing metadata/utility elements from being incorrectly normalized as content.

## 4. Risks
None evident—straightforward allowlist filtering on tag names. Ensure tag name comparison handles all HTML variants (void elements, custom elements if any).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
