### PR TITLE
[APP-2894] - One Migration flow: Move Accessibillity to One

### DIFF
--- a/assets/dev/js/api/index.js
+++ b/assets/dev/js/api/index.js
@@ -3,6 +3,7 @@ import { addQueryArgs } from '@wordpress/url';
 import APIError from './exceptions/APIError';
 
 const wpV2Prefix = '/wp/v2';
+const elementorOneV1Prefix = '/elementor-one/v1';
 const v1Prefix = '/ea11y/v1';
 
 class API {
@@ -19,7 +20,10 @@ class API {
 				headers,
 			});
 
-			if (path.startsWith(wpV2Prefix)) {
+			if (
+				path.startsWith(wpV2Prefix) ||
+				path.startsWith(elementorOneV1Prefix)
+			) {
 				return response;
 			}
 

--- a/assets/dev/js/components/notifications/index.js
+++ b/assets/dev/js/components/notifications/index.js
@@ -1,5 +1,7 @@
+import BulbIcon from '@elementor/icons/BulbIcon';
 import Alert from '@elementor/ui/Alert';
 import Snackbar from '@elementor/ui/Snackbar';
+import { styled } from '@elementor/ui/styles';
 import { useNotificationSettings } from '@ea11y-apps/global/hooks/use-notifications';
 
 const Notifications = ({ type, message }) => {
@@ -11,28 +13,63 @@ const Notifications = ({ type, message }) => {
 	} = useNotificationSettings();
 
 	const closeNotification = () => {
-		setShowNotification(!showNotification);
+		setShowNotification(false);
 		setNotificationMessage('');
 		setNotificationType('');
 	};
 
+	const getAutoHideDuration = () => {
+		switch (type) {
+			case 'error':
+				return 10000;
+			case 'hint':
+				return 8000;
+			default:
+				return 2000;
+		}
+	};
+
+	const isHint = type === 'hint';
+
 	return (
 		<Snackbar
 			open={showNotification}
-			autoHideDuration={type === 'error' ? 10000 : 2000}
+			autoHideDuration={getAutoHideDuration()}
 			onClose={closeNotification}
 			anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
 			sx={{ zIndex: 99999 }}
 		>
-			<Alert
-				onClose={() => setShowNotification(!showNotification)}
-				severity={type}
+			<StyledAlert
+				onClose={closeNotification}
+				severity={isHint ? 'info' : type}
 				variant="filled"
+				icon={isHint ? <BulbIcon /> : undefined}
+				$isHint={isHint}
 			>
 				{message}
-			</Alert>
+			</StyledAlert>
 		</Snackbar>
 	);
 };
+
+const StyledAlert = styled(Alert, {
+	shouldForwardProp: (prop) => '$isHint' !== prop,
+})`
+	${({ $isHint, theme }) =>
+		$isHint &&
+		`
+		background-color: #2d2d2d;
+		color: ${theme.palette.common.white};
+
+		& .MuiAlert-action {
+			color: ${theme.palette.common.white};
+		}
+
+		& a {
+			color: #3F8CFF;
+			text-decoration: underline;
+		}
+	`}
+`;
 
 export default Notifications;

--- a/assets/dev/js/constants/index.js
+++ b/assets/dev/js/constants/index.js
@@ -22,6 +22,9 @@ export const ELEMENTOR_URL = 'https://my.elementor.com';
 export const ONE_MISMATCH_URL =
 	'/wp-admin/admin.php?page=elementor-home#/home/url-mismatch';
 
+export const TOOL_MANAGER_URL =
+	'/wp-admin/admin.php?page=elementor-home#/home/tool-manager';
+
 export const BLOCK_TITLES = {
 	altText: __('Alternative text', 'pojo-accessibility'),
 	dynamicContent: __('Dynamic Content & ARIA', 'pojo-accessibility'),

--- a/assets/dev/js/hooks/use-notifications.js
+++ b/assets/dev/js/hooks/use-notifications.js
@@ -43,8 +43,15 @@ export const useToastNotification = () => {
 		setShowNotification(true);
 	};
 
+	const hint = (message) => {
+		setNotificationMessage(message);
+		setNotificationType('hint');
+		setShowNotification(true);
+	};
+
 	return {
 		success,
 		error,
+		hint,
 	};
 };

--- a/assets/dev/js/services/mixpanel/mixpanel-events.js
+++ b/assets/dev/js/services/mixpanel/mixpanel-events.js
@@ -65,6 +65,10 @@ export const mixpanelEvents = {
 	introductionBannerShowed: 'banner_showed',
 	introductionBannerClosed: 'banner_dismissed',
 
+	// One migration
+	oneMigrationPopupDisplayed: 'one_migration_popup_displayed',
+	oneMigrationButtonClicked: 'one_migration_button_clicked',
+
 	review: {
 		promptShown: 'review_prompt_shown',
 		dismissClicked: 'review_dismiss_clicked',

--- a/assets/dev/js/services/mixpanel/mixpanel-props/migration.js
+++ b/assets/dev/js/services/mixpanel/mixpanel-props/migration.js
@@ -1,0 +1,79 @@
+import { mixpanelEvents } from '../mixpanel-events';
+
+const MIGRATION_APP_TYPE = 'app_access';
+const MIGRATION_APP_NAME = 'accessibility';
+
+const ONE_MIGRATION_POPUP_DISPLAYED_PROPS = {
+	app_type: MIGRATION_APP_TYPE,
+	window_name: 'app_shell',
+	interaction_type: 'impression',
+	target_type: 'popup',
+	target_name: 'one_migration',
+	interaction_result: 'popup_displayed',
+	target_location: 'app_page',
+	interaction_desc:
+		'One migration popup is shown to a user who has both an active One subscription and a standalone app subscription',
+	metadata: [`app_name: ${MIGRATION_APP_NAME}`],
+};
+
+/**
+ * @param {'move_to_one' | 'not_now'}                                        button
+ * @param {'migration_success' | 'migration_failed' | 'migration_dismissed'} interactionResult
+ * @param {'success' | 'failed' | null}                                      [status]
+ * @param {string}                                                           [error]
+ */
+const buildOneMigrationButtonClickedProps = (
+	button,
+	interactionResult,
+	status = null,
+	error,
+) => {
+	const metadata = [`button: ${button}`, `status: ${status}`];
+
+	if (error) {
+		metadata.push(`error: ${error}`);
+	}
+
+	return {
+		app_type: MIGRATION_APP_TYPE,
+		window_name: 'app_shell',
+		interaction_type: 'click',
+		target_type: 'button',
+		target_name: 'one_migration_action',
+		interaction_result: interactionResult,
+		target_location: 'one_migration_popup',
+		interaction_desc:
+			'User clicks Move to One or Not now on the One migration popup; if Move to One, result reflects API outcome',
+		metadata,
+	};
+};
+
+/**
+ * @param {Function} sendEvent
+ */
+export const createOneMigrationTracking = (sendEvent) => ({
+	trackPopupDisplayed: () => {
+		sendEvent(
+			mixpanelEvents.oneMigrationPopupDisplayed,
+			ONE_MIGRATION_POPUP_DISPLAYED_PROPS,
+		);
+	},
+
+	/**
+	 * @param {'move_to_one' | 'not_now'}                                        button
+	 * @param {'migration_success' | 'migration_failed' | 'migration_dismissed'} interactionResult
+	 * @param {'success' | 'failed' | null}                                      [status]
+	 * @param {string}                                                           [error]
+	 */
+	trackButtonClicked: (button, interactionResult, status = null, error) => {
+		sendEvent(
+			mixpanelEvents.oneMigrationButtonClicked,
+			buildOneMigrationButtonClickedProps(
+				button,
+				interactionResult,
+				status,
+				error,
+			),
+		);
+	},
+});

--- a/assets/dev/js/services/mixpanel/mixpanel-service.js
+++ b/assets/dev/js/services/mixpanel/mixpanel-service.js
@@ -1,3 +1,5 @@
+import { createOneMigrationTracking } from './mixpanel-props/migration';
+
 const SHARE_USAGE_DATA = 'share_usage_data';
 const MIXPANEL_TOKEN = '150605b3b9f979922f2ac5a52e2dcfe9';
 const MIXPANEL_HOST = 'https://api-eu.mixpanel.com';
@@ -68,7 +70,10 @@ const sendEvent = (name, event) => {
 	}
 };
 
+const oneMigration = createOneMigrationTracking(sendEvent);
+
 export const mixpanelService = {
 	init,
 	sendEvent,
+	oneMigration,
 };

--- a/modules/settings/assets/js/api/index.js
+++ b/modules/settings/assets/js/api/index.js
@@ -121,6 +121,13 @@ class APISettings extends API {
 			path: `${v1Prefix}/scanner/results`,
 		});
 	}
+
+	static async migrateToOne() {
+		return APISettings.request({
+			path: '/elementor-one/v1/plugins/pojo-accessibility/migration/run',
+			method: 'POST',
+		});
+	}
 }
 
 export default APISettings;

--- a/modules/settings/assets/js/app.js
+++ b/modules/settings/assets/js/app.js
@@ -15,7 +15,7 @@ import {
 import { QuotaNotices, Sidebar } from '@ea11y/layouts';
 import Notifications from '@ea11y-apps/global/components/notifications';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
-import { lazy, Suspense, useEffect } from '@wordpress/element';
+import { lazy, Suspense, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { MenuItems } from './components/sidebar-menu/menu';
 import { usePluginSettingsContext } from './contexts/plugin-settings';
@@ -52,6 +52,12 @@ const GetStartedModal = lazy(
 			/* webpackChunkName: "chunk-modal-get-started" */ './components/help-menu/get-started-modal'
 		),
 );
+const MigrationModal = lazy(
+	() =>
+		import(
+			/* webpackChunkName: "chunk-modal-migration" */ './components/migration-modal'
+		),
+);
 
 const App = () => {
 	const { ea11ySettingsData } = window;
@@ -62,10 +68,23 @@ const App = () => {
 		isRTL,
 		closePostConnectModal,
 		isUrlMismatch,
+		isElementorOne,
+		hasElementorOneSubscription,
+		isMigrationPopupDismissed,
 		refreshPluginSettings,
 	} = usePluginSettingsContext();
 	const { notificationMessage, notificationType } = useNotificationSettings();
 	const { selectedMenu } = useSettings();
+	const [isMigrationPopupClosed, setIsMigrationPopupClosed] = useState(false);
+
+	const shouldShowMigrationPopup =
+		isConnected &&
+		!isElementorOne &&
+		hasElementorOneSubscription &&
+		closePostConnectModal &&
+		!isMigrationPopupDismissed &&
+		!isMigrationPopupClosed &&
+		!isUrlMismatch;
 
 	useEffect(() => {
 		if (ea11ySettingsData?.planData?.user?.id) {
@@ -105,6 +124,9 @@ const App = () => {
 						)}
 						{isConnected && !closePostConnectModal && <PostConnectModal />}
 						{isUrlMismatch && <UrlMismatchModal />}
+						{shouldShowMigrationPopup && (
+							<MigrationModal onClose={() => setIsMigrationPopupClosed(true)} />
+						)}
 						<OnboardingModal />
 						<GetStartedModal />
 					</Suspense>

--- a/modules/settings/assets/js/app.js
+++ b/modules/settings/assets/js/app.js
@@ -96,6 +96,16 @@ const App = () => {
 		}
 	}, [ea11ySettingsData?.planData?.user?.id]);
 
+	useEffect(() => {
+		if (!shouldShowMigrationPopup) {
+			return;
+		}
+
+		mixpanelService.init().then(() => {
+			mixpanelService.oneMigration.trackPopupDisplayed();
+		});
+	}, [shouldShowMigrationPopup]);
+
 	const selectedParent = MenuItems[selectedMenu?.parent];
 	const selectedChild = selectedMenu?.child
 		? selectedParent?.children[selectedMenu?.child]

--- a/modules/settings/assets/js/components/migration-modal/index.js
+++ b/modules/settings/assets/js/components/migration-modal/index.js
@@ -1,0 +1,207 @@
+import XIcon from '@elementor/icons/XIcon';
+import Button from '@elementor/ui/Button';
+import Dialog from '@elementor/ui/Dialog';
+import DialogActions from '@elementor/ui/DialogActions';
+import DialogContent from '@elementor/ui/DialogContent';
+import DialogHeader from '@elementor/ui/DialogHeader';
+import IconButton from '@elementor/ui/IconButton';
+import Link from '@elementor/ui/Link';
+import List from '@elementor/ui/List';
+import ListItem from '@elementor/ui/ListItem';
+import ListItemText from '@elementor/ui/ListItemText';
+import Typography from '@elementor/ui/Typography';
+import { styled } from '@elementor/ui/styles';
+import { useStorage } from '@ea11y/hooks';
+import { TOOL_MANAGER_URL } from '@ea11y-apps/global/constants';
+import { useToastNotification } from '@ea11y-apps/global/hooks';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import APISettings from '../../api';
+
+const MigrationModal = ({ onClose }) => {
+	const toast = useToastNotification();
+	const { save } = useStorage();
+	const [isLoading, setIsLoading] = useState(false);
+
+	const persistDismissed = async () => {
+		await save({
+			ea11y_migration_popup_dismissed: true,
+		});
+	};
+
+	const handleMoveToOne = async () => {
+		setIsLoading(true);
+		try {
+			const response = await APISettings.migrateToOne();
+
+			if (response?.isMigrated) {
+				onClose();
+				toast.success(
+					__(
+						'Web Accessibility has successfully moved to your One subscription.',
+						'pojo-accessibility',
+					),
+				);
+				setTimeout(() => {
+					window.location.reload();
+				}, 1500);
+			} else {
+				setIsLoading(false);
+				toast.error(
+					__(
+						'Web Accessibility could not move to your One subscription. Please try again.',
+						'pojo-accessibility',
+					),
+				);
+			}
+		} catch (err) {
+			setIsLoading(false);
+			const errorMessage =
+				err?.message ?? __('Unknown error', 'pojo-accessibility');
+			toast.error(
+				`${__('Web Accessibility could not move to your One subscription.', 'pojo-accessibility')} ${__('Error:', 'pojo-accessibility')} ${errorMessage}`,
+			);
+		}
+	};
+
+	const handleNotNow = async () => {
+		await persistDismissed();
+		onClose();
+		toast.hint(
+			<>
+				{__(
+					'You can always migrate your subscriptions from the',
+					'pojo-accessibility',
+				)}{' '}
+				<Link href={TOOL_MANAGER_URL} underline="always">
+					{__('Tool Manager', 'pojo-accessibility')}
+				</Link>
+				.
+			</>,
+		);
+	};
+
+	return (
+		<Dialog
+			open
+			onClose={handleNotNow}
+			maxWidth="sm"
+			fullWidth
+			aria-labelledby="migration-dialog-title"
+		>
+			<StyledDialogHeader logo={false}>
+				<StyledTitle
+					variant="subtitle1"
+					component="h2"
+					fontWeight={600}
+					id="migration-dialog-title"
+				>
+					{__('Move Web Accessibility to Elementor One', 'pojo-accessibility')}
+				</StyledTitle>
+				<StyledCloseButton
+					size="small"
+					onClick={handleNotNow}
+					aria-label={__('Close', 'pojo-accessibility')}
+				>
+					<XIcon />
+				</StyledCloseButton>
+			</StyledDialogHeader>
+
+			<DialogContent>
+				<Typography variant="body2" color="text.secondary" marginBlockEnd={2}>
+					{__(
+						'Web Accessibility is currently active with its own subscription. You also have an Elementor One subscription for this site.',
+						'pojo-accessibility',
+					)}
+				</Typography>
+
+				<Typography variant="body2" color="text.secondary" marginBlockEnd={1}>
+					{__('If you switch to Elementor One:', 'pojo-accessibility')}
+				</Typography>
+
+				<StyledList dense disablePadding>
+					<StyledListItem disableGutters>
+						<StyledListItemText
+							primary={__(
+								'Your current Web Accessibility subscription will be deactivated',
+								'pojo-accessibility',
+							)}
+						/>
+					</StyledListItem>
+					<StyledListItem disableGutters>
+						<StyledListItemText
+							primary={__(
+								'Web Accessibility will use your shared Elementor One credits',
+								'pojo-accessibility',
+							)}
+						/>
+					</StyledListItem>
+				</StyledList>
+			</DialogContent>
+
+			<StyledDialogActions>
+				<Button
+					color="secondary"
+					variant="outlined"
+					onClick={handleNotNow}
+					disabled={isLoading}
+				>
+					{__('Not now', 'pojo-accessibility')}
+				</Button>
+				<Button
+					variant="contained"
+					onClick={handleMoveToOne}
+					disabled={isLoading}
+				>
+					{__('Move to One', 'pojo-accessibility')}
+				</Button>
+			</StyledDialogActions>
+		</Dialog>
+	);
+};
+
+const StyledDialogHeader = styled(DialogHeader)`
+	position: relative;
+
+	> div {
+		padding: ${({ theme }) => `
+			${theme.spacing(2)} 
+			${theme.spacing(4.5)}
+			${theme.spacing(2)}
+			${theme.spacing(2.75)}
+		`};
+		min-height: auto;
+	}
+`;
+
+const StyledTitle = styled(Typography)`
+	line-height: 1.5;
+`;
+
+const StyledCloseButton = styled(IconButton)`
+	position: absolute;
+	right: ${({ theme }) => theme.spacing(1)};
+	top: ${({ theme }) => theme.spacing(1)};
+`;
+
+const StyledList = styled(List)`
+	padding-inline-start: ${({ theme }) => theme.spacing(2)};
+	list-style-type: disc;
+`;
+
+const StyledListItem = styled(ListItem)`
+	padding-block: 0;
+	min-height: auto;
+`;
+
+const StyledListItemText = styled(ListItemText)`
+	display: list-item;
+	color: ${({ theme }) => theme.palette.text.secondary};
+	margin: 0;
+`;
+
+const StyledDialogActions = styled(DialogActions)`
+	padding: ${({ theme }) => theme.spacing(2, 3)};
+`;
+
+export default MigrationModal;

--- a/modules/settings/assets/js/components/migration-modal/index.js
+++ b/modules/settings/assets/js/components/migration-modal/index.js
@@ -14,6 +14,7 @@ import { styled } from '@elementor/ui/styles';
 import { useStorage } from '@ea11y/hooks';
 import { TOOL_MANAGER_URL } from '@ea11y-apps/global/constants';
 import { useToastNotification } from '@ea11y-apps/global/hooks';
+import { mixpanelService } from '@ea11y-apps/global/services';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import APISettings from '../../api';
@@ -29,12 +30,27 @@ const MigrationModal = ({ onClose }) => {
 		});
 	};
 
+	const trackButtonClick = (
+		button,
+		interactionResult,
+		status = null,
+		error,
+	) => {
+		mixpanelService.oneMigration.trackButtonClicked(
+			button,
+			interactionResult,
+			status,
+			error,
+		);
+	};
+
 	const handleMoveToOne = async () => {
 		setIsLoading(true);
 		try {
 			const response = await APISettings.migrateToOne();
 
 			if (response?.isMigrated) {
+				trackButtonClick('move_to_one', 'migration_success', 'success');
 				onClose();
 				toast.success(
 					__(
@@ -47,6 +63,7 @@ const MigrationModal = ({ onClose }) => {
 				}, 1500);
 			} else {
 				setIsLoading(false);
+				trackButtonClick('move_to_one', 'migration_failed', 'failed');
 				toast.error(
 					__(
 						'Web Accessibility could not move to your One subscription. Please try again.',
@@ -58,6 +75,12 @@ const MigrationModal = ({ onClose }) => {
 			setIsLoading(false);
 			const errorMessage =
 				err?.message ?? __('Unknown error', 'pojo-accessibility');
+			trackButtonClick(
+				'move_to_one',
+				'migration_failed',
+				'failed',
+				err?.code ?? errorMessage,
+			);
 			toast.error(
 				`${__('Web Accessibility could not move to your One subscription.', 'pojo-accessibility')} ${__('Error:', 'pojo-accessibility')} ${errorMessage}`,
 			);
@@ -65,6 +88,7 @@ const MigrationModal = ({ onClose }) => {
 	};
 
 	const handleNotNow = async () => {
+		trackButtonClick('not_now', 'migration_dismissed', null);
 		await persistDismissed();
 		onClose();
 		toast.hint(

--- a/modules/settings/assets/js/contexts/plugin-settings.js
+++ b/modules/settings/assets/js/contexts/plugin-settings.js
@@ -57,6 +57,18 @@ export const PluginSettingsProvider = ({ children }) => {
 					settings.isElementorOne = Boolean(settings.isElementorOne);
 				}
 
+				if ('hasElementorOneSubscription' in settings) {
+					settings.hasElementorOneSubscription = Boolean(
+						settings.hasElementorOneSubscription,
+					);
+				}
+
+				if ('isMigrationPopupDismissed' in settings) {
+					settings.isMigrationPopupDismissed = Boolean(
+						settings.isMigrationPopupDismissed,
+					);
+				}
+
 				setPluginSettings(settings);
 				setLoaded(true);
 			})

--- a/modules/settings/classes/settings.php
+++ b/modules/settings/classes/settings.php
@@ -12,6 +12,7 @@ class Settings {
 	public const CLOSE_POST_CONNECT_MODAL = 'ea11y_close_post_connect_modal';
 	public const CLOSE_ONBOARDING_MODAL = 'ea11y_close_onboarding_modal';
 	public const CLOSE_GET_STARTED_MODAL = 'ea11y_close_get_started_modal';
+	public const MIGRATION_POPUP_DISMISSED = 'ea11y_migration_popup_dismissed';
 
 	public const IS_VALID_PLAN_DATA = 'ea11y_is_valid_plan_data';
 	public const PLAN_DATA = 'ea11y_plan_data';

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -149,6 +149,8 @@ class Module extends Module_Base {
 			'unfilteredUploads' => Svg::are_unfiltered_uploads_enabled(),
 			'homeUrl' => home_url(),
 			'isElementorOne' => self::is_elementor_one(),
+			'hasElementorOneSubscription' => self::has_elementor_one_subscription(),
+			'isMigrationPopupDismissed' => Settings::get( Settings::MIGRATION_POPUP_DISMISSED ),
 			'widgetActivationSettings' => Settings::get( Settings::WIDGET_ACTIVATION ),
 		];
 	}
@@ -170,6 +172,15 @@ class Module extends Module_Base {
 	 */
 	public static function is_elementor_one(): bool {
 		return Connect::get_connect()->get_config( 'app_type' ) !== Config::APP_TYPE;
+	}
+
+	/**
+	 * Check if user generally has an active Elementor One subscription.
+	 * @return bool
+	 */
+	public static function has_elementor_one_subscription(): bool {
+		$one_facade = \ElementorOne\Admin\Helpers\Utils::get_one_connect();
+		return $one_facade && $one_facade->utils()->is_connected();
 	}
 
 	/**
@@ -554,6 +565,9 @@ class Module extends Module_Base {
 				'type' => 'boolean',
 			],
 			'close_get_started_modal' => [
+				'type' => 'boolean',
+			],
+			'migration_popup_dismissed' => [
 				'type' => 'boolean',
 			],
 			'dismissed_quota_notices' => [


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
APP-2894: Users with both standalone Accessibility and Elementor One subscriptions need a migration UI to consolidate under One, reducing subscription management friction.

## 2. What Changed (Where)

| Component | Change |
|-----------|--------|
| **API layer** | Added `/elementor-one/v1` prefix support; new `migrateToOne()` endpoint; updated request routing to accept One API responses |
| **Migration modal** | New component with UX handling user flow: prompt → migrate/dismiss → success/error toast + reload |
| **Notifications** | Enhanced with hint type, dynamic auto-hide duration, custom styling for non-error alerts |
| **Tracking** | New Mixpanel integration: popup display + button clicks with migration status/errors |
| **State management** | Plugin settings: `hasElementorOneSubscription`, `isMigrationPopupDismissed` flags; modal visibility logic in App context |
| **PHP settings** | Added `MIGRATION_POPUP_DISMISSED` constant; server-side subscription check via ElementorOne facade |

## 3. How It Works

Popup displays when: connected + !isElementorOne + hasOneSubscription + dismissal not persisted. "Move to One" calls `APISettings.migrateToOne()` → on success, persists flag + reloads; "Not Now" saves dismissal flag + shows hint toast linking to Tool Manager. Auto-hide durations: error 10s, hint 8s, success 2s.

## 4. Risks

**API routing assumption**: Code assumes One endpoints (elementor-one/v1) return `success: true` + data directly; validate endpoint contract matches response structure. **Reload timing**: 1.5s delay post-migration may lose state if user navigates—consider confirming migration persisted server-side first.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
