### PR TITLE
[APP-2942] - A11y - Fix radio button selection within the labels on the deactivation screen

### DIFF
--- a/modules/deactivation/assets/css/style.css
+++ b/modules/deactivation/assets/css/style.css
@@ -9,8 +9,7 @@
 
 #TB_window.ea11y-feedback-thickbox {
     height: auto !important;
-    max-height: 90vh;
-    overflow: auto;
+    overflow: visible;
     top: 50% !important;
     left: 50% !important;
     transform: translate(-50%, -50%) !important;
@@ -22,7 +21,12 @@
 
 .ea11y-feedback-thickbox #TB_ajaxContent {
     overflow: visible;
+    height: auto !important;
     padding: 0;
+}
+
+.ea11y-deactivation-content > h4 {
+    margin-block-start: 0;
 }
 
 .ea11y-feedback-thickbox #TB_title {
@@ -30,6 +34,7 @@
     display: flex;
     flex-direction: row;
     text-align: start;
+    border-radius: 8px 8px 0 0;
 }
 
 .ea11y-feedback-thickbox #TB_closeWindowButton {
@@ -66,23 +71,26 @@
 
 .ea11y-feedback-option {
     margin-block-end: 15px;
+    cursor: pointer;
 }
 
 .ea11y-feedback-option > label {
     display: flex;
     align-items: center;
+    width: 100%;
     cursor: pointer;
     color: #23282d;
     margin-block-end: 8px;
 }
 
-.ea11y-feedback-option input[type="radio"] {
-    margin-inline-end: 8px;
-}
-
 .ea11y-feedback-text-field {
+    cursor: default;
     margin-inline-start: 24px;
     margin-block-start: 8px;
+}
+
+.ea11y-feedback-option input[type="radio"] {
+    margin-inline-end: 8px;
 }
 
 .ea11y-feedback-text-field label {

--- a/modules/deactivation/assets/js/deactivation-feedback.js
+++ b/modules/deactivation/assets/js/deactivation-feedback.js
@@ -2,9 +2,9 @@ import { __ } from '@wordpress/i18n';
 import '../css/style.css';
 
 const REASON_FIELDS = {
-	unclear_how_to_use: ['text_field_unclear', 'unclear_details'],
-	switched_solution: ['text_field_switched', 'switched_details'],
-	other: ['text_field_other', 'other_details'],
+	unclear_how_to_use: ['ea11y_text_field_unclear', 'ea11y_unclear_details'],
+	switched_solution: ['ea11y_text_field_switched', 'ea11y_switched_details'],
+	other: ['ea11y_text_field_other', 'ea11y_other_details'],
 };
 
 class Ea11yDeactivationHandler {
@@ -30,6 +30,15 @@ class Ea11yDeactivationHandler {
 		);
 	}
 
+	resetModal() {
+		this.hideFields();
+		document
+			.querySelectorAll('input[name="ea11y_deactivation_reason"]')
+			.forEach((radio) => {
+				radio.checked = false;
+			});
+	}
+
 	hideFields() {
 		document
 			.querySelectorAll('.ea11y-feedback-text-field')
@@ -38,10 +47,32 @@ class Ea11yDeactivationHandler {
 
 	toggleField(reason) {
 		this.hideFields();
+
 		const fieldId = REASON_FIELDS[reason]?.[0];
+
 		if (fieldId) {
 			document.getElementById(fieldId).style.display = 'block';
 		}
+	}
+
+	handleOptionClick(e) {
+		const option = e.target.closest('.ea11y-feedback-option');
+
+		if (!option || e.target.closest('.ea11y-feedback-text-field')) {
+			return;
+		}
+
+		const radio = option.querySelector(
+			'input[type="radio"][name="ea11y_deactivation_reason"]',
+		);
+
+		if (!radio) {
+			return;
+		}
+
+		radio.checked = true;
+
+		this.toggleField(radio.value);
 	}
 
 	sendRequest(data, done) {
@@ -84,6 +115,7 @@ class Ea11yDeactivationHandler {
 	init() {
 		this.deactivationLink.addEventListener('click', (e) => {
 			e.preventDefault();
+			this.resetModal();
 			this.modal(
 				__('Quick feedback', 'pojo-accessibility'),
 				'#TB_inline?width=600&height=auto&inlineId=ea11y-deactivation-modal',
@@ -101,11 +133,17 @@ class Ea11yDeactivationHandler {
 			if (e.target?.id === 'ea11y-submit-deactivate') {
 				e.preventDefault();
 				this.handleSubmit();
+
+				return;
 			}
 			if (e.target?.id === 'ea11y-skip-deactivate') {
 				e.preventDefault();
 				this.deactivate();
+
+				return;
 			}
+
+			this.handleOptionClick(e);
 		});
 	}
 }

--- a/modules/deactivation/module.php
+++ b/modules/deactivation/module.php
@@ -80,63 +80,63 @@ class Module extends Module_Base {
 
 				<div class="ea11y-feedback-options">
 					<div class="ea11y-feedback-option">
-						<label for="reason_no_longer_needed">
-							<input type="radio" name="ea11y_deactivation_reason" value="no_longer_needed" id="reason_no_longer_needed">
+						<label>
+							<input type="radio" name="ea11y_deactivation_reason" value="no_longer_needed" id="ea11y_reason_no_longer_needed">
 							<?php esc_html_e( 'I no longer need this plugin', 'pojo-accessibility' ); ?>
 						</label>
 					</div>
 
 					<div class="ea11y-feedback-option">
-						<label for="reason_too_expensive">
-							<input type="radio" name="ea11y_deactivation_reason" value="too_expensive" id="reason_too_expensive">
+						<label>
+							<input type="radio" name="ea11y_deactivation_reason" value="too_expensive" id="ea11y_reason_too_expensive">
 							<?php esc_html_e( 'It\'s too expensive', 'pojo-accessibility' ); ?>
 						</label>
 					</div>
 
 					<div class="ea11y-feedback-option">
-						<label for="reason_no_results">
-							<input type="radio" name="ea11y_deactivation_reason" value="no_results" id="reason_no_results">
+						<label>
+							<input type="radio" name="ea11y_deactivation_reason" value="no_results" id="ea11y_reason_no_results">
 							<?php esc_html_e( 'The plugin didn\'t provide the results I was hoping for', 'pojo-accessibility' ); ?>
 						</label>
 					</div>
 
 					<div class="ea11y-feedback-option">
-						<label for="reason_unclear">
-							<input type="radio" name="ea11y_deactivation_reason" value="unclear_how_to_use" id="reason_unclear">
+						<label>
+							<input type="radio" name="ea11y_deactivation_reason" value="unclear_how_to_use" id="ea11y_reason_unclear">
 							<?php esc_html_e( 'I wasn\'t sure how to use the plugin', 'pojo-accessibility' ); ?>
 						</label>
-						<div class="ea11y-feedback-text-field" id="text_field_unclear" style="display: none;">
-							<label for="unclear_details"><?php esc_html_e( 'Optional: Was anything unclear or confusing?', 'pojo-accessibility' ); ?></label>
-							<textarea id="unclear_details" name="unclear_details" rows="3" placeholder="<?php esc_attr_e( 'Please share details...', 'pojo-accessibility' ); ?>"></textarea>
+						<div class="ea11y-feedback-text-field" id="ea11y_text_field_unclear" style="display: none;">
+							<label for="ea11y_unclear_details"><?php esc_html_e( 'Optional: Was anything unclear or confusing?', 'pojo-accessibility' ); ?></label>
+							<textarea id="ea11y_unclear_details" name="ea11y_unclear_details" rows="3" placeholder="<?php esc_attr_e( 'Please share details...', 'pojo-accessibility' ); ?>"></textarea>
 						</div>
 					</div>
 
 					<div class="ea11y-feedback-option">
-						<label for="reason_technical">
-							<input type="radio" name="ea11y_deactivation_reason" value="technical_issues" id="reason_technical">
+						<label>
+							<input type="radio" name="ea11y_deactivation_reason" value="technical_issues" id="ea11y_reason_technical">
 							<?php esc_html_e( 'I had technical issues or conflicts with my site', 'pojo-accessibility' ); ?>
 						</label>
 					</div>
 
 					<div class="ea11y-feedback-option">
-						<label for="reason_switched">
-							<input type="radio" name="ea11y_deactivation_reason" value="switched_solution" id="reason_switched">
+						<label>
+							<input type="radio" name="ea11y_deactivation_reason" value="switched_solution" id="ea11y_reason_switched">
 							<?php esc_html_e( 'I switched to a different solution', 'pojo-accessibility' ); ?>
 						</label>
-						<div class="ea11y-feedback-text-field" id="text_field_switched" style="display: none;">
-							<label for="switched_details"><?php esc_html_e( 'Optional: Please share which solution:', 'pojo-accessibility' ); ?></label>
-							<input type="text" id="switched_details" name="switched_details" placeholder="<?php esc_attr_e( 'Solution name...', 'pojo-accessibility' ); ?>">
+						<div class="ea11y-feedback-text-field" id="ea11y_text_field_switched" style="display: none;">
+							<label for="ea11y_switched_details"><?php esc_html_e( 'Optional: Please share which solution:', 'pojo-accessibility' ); ?></label>
+							<input type="text" id="ea11y_switched_details" name="ea11y_switched_details" placeholder="<?php esc_attr_e( 'Solution name...', 'pojo-accessibility' ); ?>">
 						</div>
 					</div>
 
 					<div class="ea11y-feedback-option">
-						<label for="reason_other">
-							<input type="radio" name="ea11y_deactivation_reason" value="other" id="reason_other">
+						<label>
+							<input type="radio" name="ea11y_deactivation_reason" value="other" id="ea11y_reason_other">
 							<?php esc_html_e( 'Other', 'pojo-accessibility' ); ?>
 						</label>
-						<div class="ea11y-feedback-text-field" id="text_field_other" style="display: none;">
-							<label for="other_details"><?php esc_html_e( 'Optional: Please share the reason:', 'pojo-accessibility' ); ?></label>
-							<textarea id="other_details" name="other_details" rows="3" placeholder="<?php esc_attr_e( 'Please explain...', 'pojo-accessibility' ); ?>"></textarea>
+						<div class="ea11y-feedback-text-field" id="ea11y_text_field_other" style="display: none;">
+							<label for="ea11y_other_details"><?php esc_html_e( 'Optional: Please share the reason:', 'pojo-accessibility' ); ?></label>
+							<textarea id="ea11y_other_details" name="ea11y_other_details" rows="3" placeholder="<?php esc_attr_e( 'Please explain...', 'pojo-accessibility' ); ?>"></textarea>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Radio buttons weren't clickable within their label text due to missing label wrapping and improper event delegation. This fix restructures markup to wrap inputs in labels and adds click handling for the entire option container to meet a11y standards.

## 2. What Changed (Where)

- `module.php`: Wrapped radio inputs directly in `<label>` tags, prefixed field IDs with `ea11y_` for consistency, moved textarea/input fields outside labels
- `deactivation-feedback.js`: Added `handleOptionClick()` for click delegation, `resetModal()` to clear state, updated `REASON_FIELDS` keys to match new IDs
- `style.css`: Added `cursor: pointer` to options, set `overflow: visible`, adjusted modal/label width, moved radio margin rule position

## 3. How It Works

User clicks anywhere within `.ea11y-feedback-option` → `handleOptionClick()` delegates to find the radio input → sets `checked = true` and calls `toggleField()` to show conditional details field. Modal resets on each open via `resetModal()` clearing prior selections.

## 4. Risks

None significant. Label wrapping is semantic best-practice. Delegation avoids event listener proliferation. Field ID rename is scoped to this feature with no external dependencies.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
