### PR TITLE
[APP-2954] fix selector to use fallback snippet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ coverage/
 .env
 *.zip
 .qodo
+.playwright-mcp/

--- a/modules/remediation/actions/attribute.php
+++ b/modules/remediation/actions/attribute.php
@@ -17,9 +17,10 @@ class Attribute extends Remediation_Base {
 	public static string $type = 'attribute';
 
 	public function run() : ?DOMDocument {
-		$element_node = $this->data['global']
-			? $this->get_element_by_xpath_with_snippet_fallback( $this->data['xpath'], $this->data['find'] )
-			: $this->get_element_by_xpath( $this->data['xpath'] );
+		$element_node = $this->get_element_by_xpath_with_snippet_fallback(
+			$this->data['xpath'] ?? null,
+			$this->data['find'] ?? null
+		);
 
 		if ( ! $element_node ) {
 			$this->use_frontend = true;

--- a/modules/remediation/actions/replace.php
+++ b/modules/remediation/actions/replace.php
@@ -17,9 +17,10 @@ class Replace extends Remediation_Base {
 	public static string $type = 'replace';
 
 	public function run() : ?DOMDocument {
-		$element_node = $this->data['global']
-			? $this->get_element_by_xpath_with_snippet_fallback( $this->data['xpath'], $this->data['find'] )
-			: $this->get_element_by_xpath( $this->data['xpath'] );
+		$element_node = $this->get_element_by_xpath_with_snippet_fallback(
+			$this->data['xpath'] ?? null,
+			$this->data['find'] ?? null
+		);
 
 		if ( ! $element_node instanceof \DOMElement ) {
 			$this->use_frontend = true;

--- a/modules/remediation/assets/js/actions/attribute.js
+++ b/modules/remediation/assets/js/actions/attribute.js
@@ -8,14 +8,11 @@ export class AttributeRemediation extends RemediationBase {
 			action,
 			attribute_name: attributeName,
 			attribute_value: attributeValue,
-			global: isGlobal,
+			find,
 		} = this.data;
 
 		const xpath = originXpath.replace('svg', "*[name()='svg']");
-		const el =
-			isGlobal === '1'
-				? this.getElementByXPathFallbackSnippet(find, xpath)
-				: this.getElementByXPath(xpath);
+		const el = this.getElementByXPathFallbackSnippet(find, xpath);
 		if (!el) {
 			return false;
 		}

--- a/modules/remediation/assets/js/actions/base.js
+++ b/modules/remediation/assets/js/actions/base.js
@@ -37,35 +37,36 @@ export class RemediationBase {
 	}
 
 	getElementByXPathFallbackSnippet(snippet, xpath = null) {
-		// Try XPath first
-		if (xpath) {
-			const element = this.getElementByXPath(xpath);
-			if (element) {
-				// Pick the one whose outerHTML best matches the snippet
-				const normalizedSnippet = snippet
-					.replace(/\s+/g, ' ')
-					.trim()
-					.toLowerCase();
-				const html = element.outerHTML
-					.replace(/\s+/g, ' ')
-					.trim()
-					.toLowerCase();
-				if (html.includes(normalizedSnippet)) {
-					return element;
-				}
+		const xpathElement = xpath ? this.getElementByXPath(xpath) : null;
+		const hasSnippet = typeof snippet === 'string' && snippet.trim() !== '';
+
+		if (xpathElement && hasSnippet) {
+			const normalizedSnippet = snippet
+				.replace(/\s+/g, ' ')
+				.trim()
+				.toLowerCase();
+			const html = xpathElement.outerHTML
+				.replace(/\s+/g, ' ')
+				.trim()
+				.toLowerCase();
+			if (html.includes(normalizedSnippet)) {
+				return xpathElement;
 			}
+		}
+
+		if (!hasSnippet) {
+			return xpathElement || null;
 		}
 
 		const parser = new DOMParser();
 		const doc = parser.parseFromString(snippet.trim(), 'text/html');
 		const parsed = doc.body.firstElementChild;
 		if (!parsed) {
-			return null;
+			return xpathElement || null;
 		}
 
 		const selectorParts = [parsed.tagName.toLowerCase()];
 
-		// Add id and class if present
 		if (parsed.id) {
 			selectorParts.push(`#${parsed.id}`);
 		}
@@ -75,8 +76,7 @@ export class RemediationBase {
 
 		const selector = selectorParts.join('');
 
-		// Try to find it in the document
-		return document.querySelector(selector);
+		return document.querySelector(selector) || xpathElement || null;
 	}
 
 	createElement(tag, attributes = [], content = '') {

--- a/modules/remediation/assets/js/actions/replace.js
+++ b/modules/remediation/assets/js/actions/replace.js
@@ -14,11 +14,8 @@ export class ReplaceRemediation extends RemediationBase {
 	}
 
 	run() {
-		const { xpath, find, replace, global: isGlobal } = this.data;
-		const el =
-			isGlobal === '1'
-				? this.getElementByXPathFallbackSnippet(find, xpath)
-				: this.getElementByXPath(xpath);
+		const { xpath, find, replace } = this.data;
+		const el = this.getElementByXPathFallbackSnippet(find, xpath);
 
 		if (!el) {
 			return false;

--- a/modules/remediation/classes/remediation-base.php
+++ b/modules/remediation/classes/remediation-base.php
@@ -35,6 +35,18 @@ class Remediation_Base {
 	}
 
 	/**
+	 * Check if the element exists using XPath with a snippet-based fallback.
+	 *
+	 * @return boolean
+	 */
+	public function exists_with_fallback(): bool {
+		return $this->get_element_by_xpath_with_snippet_fallback(
+			$this->data['xpath'] ?? null,
+			$this->data['find'] ?? null
+		) instanceof DOMElement;
+	}
+
+	/**
 	 * get_element_by_xpath
 	 * @param $xpath
 	 *
@@ -161,8 +173,9 @@ class Remediation_Base {
 	public function __construct( DOMDocument $dom, $data ) {
 		$this->dom = $dom;
 		$this->data = $data;
-		// if it's not global and not styles and element does not exist, move the remediation to the Frontend
-		if ( 'STYLES' !== $this->data['type'] && ! $this->data['global'] && ! $this->exists() ) {
+		// If it's not styles and the element can't be found by XPath or the snippet fallback,
+		// move the remediation to the Frontend so a later DOM state can pick it up.
+		if ( 'STYLES' !== $this->data['type'] && ! $this->exists_with_fallback() ) {
 			$this->use_frontend = true;
 			return;
 		}

--- a/modules/remediation/classes/remediation-base.php
+++ b/modules/remediation/classes/remediation-base.php
@@ -72,18 +72,20 @@ class Remediation_Base {
 	 * @return DOMElement|null
 	 */
 	public function get_element_by_xpath_with_snippet_fallback( ?string $xpath, ?string $snippet ): ?DOMElement {
-		if ( ! $xpath ) {
-			return null;
+		$element = $xpath ? $this->get_element_by_xpath( $xpath ) : null;
+
+		// Without a snippet we can't validate or fall back, so return whatever XPath found.
+		if ( null === $snippet || '' === $snippet ) {
+			return $element instanceof DOMElement ? $element : null;
 		}
 
-		$element  = $this->get_element_by_xpath( $xpath );
-		if ( $element && ! $this->element_contains_snippet( $element, $snippet ) ) {
-			// XPath result doesn't contain the snippet
+		// If XPath found an element but its outer HTML doesn't contain the snippet, discard it.
+		if ( $element instanceof DOMElement && ! $this->element_contains_snippet( $element, $snippet ) ) {
 			$element = null;
 		}
 
-		// Fallback to snippet-based search
-		if ( ! $element ) {
+		// Fallback to snippet-based search.
+		if ( ! $element instanceof DOMElement ) {
 			$element = $this->get_element_by_snippet( $snippet );
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
 				"focus-trap-react": "^11.0.4",
 				"get-xpath": "^3.3.0",
 				"html-react-parser": "^5.2.2",
-				"mixpanel-browser": "^2.58.0",
+				"mixpanel-browser": "^2.80.0",
 				"postcss": "^8.5.6",
 				"prop-types": "^15.8.1",
 				"react-colorful": "^5.6.1",
@@ -24743,9 +24743,9 @@
 			}
 		},
 		"node_modules/mixpanel-browser": {
-			"version": "2.79.0",
-			"resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.79.0.tgz",
-			"integrity": "sha512-+XRUJfplXy6bwW85ZOEIABlxZyfAVgyBPfMO0QiWr6wkRbvpWbS4xCPTR6iEl5ATPN8+ae+Nv4vusANjrk0DEA==",
+			"version": "2.80.0",
+			"resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.80.0.tgz",
+			"integrity": "sha512-kzhUk5dopABfF7rkKGHofR3fxPIK/OIDLqtwGyPN3PUTVUCNZqMY+gyionhMqjiOpL4ipXecT9YfF4siEre0GA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mixpanel/rrweb": "2.0.0-alpha.18.4",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"focus-trap-react": "^11.0.4",
 		"get-xpath": "^3.3.0",
 		"html-react-parser": "^5.2.2",
-		"mixpanel-browser": "^2.58.0",
+		"mixpanel-browser": "^2.80.0",
 		"postcss": "^8.5.6",
 		"prop-types": "^15.8.1",
 		"react-colorful": "^5.6.1",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Removes the `global` flag condition that gated snippet-based fallback lookup. Now *always* uses fallback for robust element selection, handling XPath misses gracefully.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `attribute.js`, `replace.js` | Remove `global` conditional; always call `getElementByXPathFallbackSnippet()` |
| `base.js` | Refactor fallback logic: try XPath first, validate snippet match, fall back to snippet-based querySelector |
| `attribute.php`, `replace.php` | Remove `global` check; unconditionally use snippet fallback method |
| `remediation-base.php` | Add `exists_with_fallback()` method; use it in constructor instead of `exists()` + `global` check |
| `package.json` | Bump `mixpanel-browser` from 2.58.0 to 2.80.0 |

## 3. How It Works

Frontend: `getElementByXPathFallbackSnippet()` now (1) tries XPath, (2) validates via snippet match if found, (3) falls back to CSS selector built from parsed snippet. Backend mirrors this in `get_element_by_xpath_with_snippet_fallback()`, with early exits for missing snippets. Constructor now calls `exists_with_fallback()` instead of conditional logic, moving remediation frontend-side when neither XPath nor snippet succeeds.

## 4. Risks

Fallback selector built from `tagName + id + classes` is fragile—two elements matching same pattern will grab first. Consider validating snippet match in fallback result (frontend already does, backend doesn't). Mixpanel bump unrelated—verify no breaking changes.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
