### PR TITLE
fix(remediation): protect inline script/style blocks from DOMDocument round-trip (APP-3016)

### DIFF
--- a/modules/remediation/classes/utils.php
+++ b/modules/remediation/classes/utils.php
@@ -140,6 +140,25 @@ class Utils {
 		return md5( $text );
 	}
 
+	/**
+	 * Version salt for the rendered-HTML cache (Page_Entry::FULL_HTML).
+	 *
+	 * Bump this whenever the remediation rendering pipeline changes so that
+	 * previously cached HTML is treated as stale and regenerated on the next
+	 * request instead of being served as-is.
+	 */
+	const HTML_CACHE_VERSION = '2';
+
+	/**
+	 * Versioned hash used to validate cached rendered HTML.
+	 *
+	 * @param string $text
+	 * @return string
+	 */
+	public static function get_cache_hash( $text ) : string {
+		return md5( self::HTML_CACHE_VERSION . $text );
+	}
+
 	public static function trigger_save_for_clean_cache( $entry_id, $entry_type ): void {
 		$entry_id = (int) $entry_id;
 		$post_types = get_post_types([

--- a/modules/remediation/classes/utils.php
+++ b/modules/remediation/classes/utils.php
@@ -136,10 +136,6 @@ class Utils {
 		return 'unknown';
 	}
 
-	public static function get_hash( $text ) : string {
-		return md5( $text );
-	}
-
 	/**
 	 * Version salt for the rendered-HTML cache (Page_Entry::FULL_HTML).
 	 *

--- a/modules/remediation/components/remediation-runner.php
+++ b/modules/remediation/components/remediation-runner.php
@@ -238,8 +238,17 @@ class Remediation_Runner {
 	}
 
 	private function generate_remediation_dom( $buffer ): string {
+		// Inline <script> and <style> blocks are not round-trip safe through
+		// DOMDocument::loadHTML()/saveHTML(): libxml entity-encodes characters
+		// such as `<`, `>`, and `&` inside them, which corrupts inline
+		// JavaScript (e.g. WooCommerce archive scripts) and surfaces as a
+		// console syntax error that breaks the page layout. Stash them as
+		// placeholder comments before parsing and restore the original markup
+		// verbatim after serialization.
+		[ $protected_buffer, $placeholders ] = $this->stash_inline_assets( $buffer );
+
 		$dom = new DOMDocument( '1.0', 'UTF-8' );
-		$dom->loadHTML( $buffer, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOERROR );
+		$dom->loadHTML( $protected_buffer, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOERROR );
 
 		//Remove admin-bar for correct replace
 		$admin_bar = $dom->getElementById( 'wpadminbar' );
@@ -302,7 +311,58 @@ class Remediation_Runner {
 				$head->appendChild( $module_script );
 			}
 		}
-		return $dom->saveHTML();
+		return $this->restore_inline_assets( $dom->saveHTML(), $placeholders );
+	}
+
+	/**
+	 * Replace inline <script> and <style> blocks with placeholder comments
+	 * so their contents survive the DOMDocument load/save round-trip intact.
+	 *
+	 * @param string $buffer Raw page HTML.
+	 * @return array{0:string,1:array<string,string>} Protected buffer and map of placeholder keys to original blocks.
+	 */
+	private function stash_inline_assets( string $buffer ): array {
+		$placeholders = [];
+		$pattern       = '/<(script|style)\b[^>]*>.*?<\/\1>/is';
+
+		$protected = preg_replace_callback(
+			$pattern,
+			static function ( $matches ) use ( &$placeholders ) {
+				$key                 = 'EA11YPROTECT' . count( $placeholders );
+				$placeholders[ $key ] = $matches[0];
+				return '<!--' . $key . '-->';
+			},
+			$buffer
+		);
+
+		return [ null === $protected ? $buffer : (string) $protected, $placeholders ];
+	}
+
+	/**
+	 * Restore the original inline <script> and <style> blocks that were
+	 * replaced with placeholder comments by stash_inline_assets().
+	 *
+	 * @param string                $html         Serialized HTML from DOMDocument::saveHTML().
+	 * @param array<string,string>  $placeholders Map of placeholder keys to original blocks.
+	 * @return string
+	 */
+	private function restore_inline_assets( string $html, array $placeholders ): string {
+		foreach ( $placeholders as $key => $original ) {
+			$pattern  = '/<!--\s*' . preg_quote( $key, '/' ) . '\s*-->/';
+			$replaced = preg_replace_callback(
+				$pattern,
+				static function () use ( $original ) {
+					return $original;
+				},
+				$html,
+				1
+			);
+			if ( null !== $replaced ) {
+				$html = (string) $replaced;
+			}
+		}
+
+		return $html;
 	}
 
 	private function add_frontend_remediation( $remediation ) {

--- a/modules/remediation/database/page-entry.php
+++ b/modules/remediation/database/page-entry.php
@@ -54,7 +54,7 @@ class Page_Entry extends Entry {
 			return null;
 		}
 
-		$this->entry_data[ Page_Table::HASH ] = Utils::get_hash( $this->entry_data[ Page_Table::UPDATED_AT ] );
+		$this->entry_data[ Page_Table::HASH ] = Utils::get_cache_hash( $this->entry_data[ Page_Table::UPDATED_AT ] );
 		$this->entry_data[ Page_Table::FULL_HTML ] = $html;
 
 		$this->save();
@@ -121,7 +121,7 @@ class Page_Entry extends Entry {
 	 * @return bool
 	 */
 	public function is_valid_hash() : bool {
-		$current_hash = Utils::get_hash( $this->entry_data[ Page_Table::UPDATED_AT ] );
+		$current_hash = Utils::get_cache_hash( $this->entry_data[ Page_Table::UPDATED_AT ] );
 		return ! empty( $this->entry_data[ Page_Table::HASH ] ) && $this->entry_data[ Page_Table::HASH ] === $current_hash;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Scanner dashboard: Track your site's accessibility scans, monitor open issues, and follow progress over time.
 
 == Changelog ==
+= 4.1.4 – Unreleased =
+* Fix: Prevented the remediation runner from corrupting inline `<script>` and `<style>` blocks (e.g. WooCommerce archive scripts with multibyte characters) during the DOMDocument round-trip, which caused console syntax errors and broken page layouts
+* Tweak: Versioned the rendered-HTML cache so previously cached (potentially corrupted) HTML is regenerated after the rendering pipeline changes
+
 = 4.1.3 – 2026-06-29 =
 * Tweak: Widget button custom position alignment
 * Tweak: Ally AI fixes improvments


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Ally-side root cause of [APP-3016](https://elementor.atlassian.net/browse/APP-3016): a WooCommerce product archive page with a filter sidebar breaks (layout collapses, "shows headers and tags") and throws a console syntax error once Ally is active.

## Root cause

`Remediation_Runner::generate_remediation_dom()` parses the whole page through `DOMDocument::loadHTML()` and re-serializes it with `saveHTML()`. libxml's HTML parser is not round-trip safe for inline `<script>` and `<style>` content. In particular, when a page has no explicit encoding declaration, libxml assumes ISO-8859-1 and **entity-encodes multibyte UTF-8 bytes inside `<script>` blocks** (e.g. `€` → `&acirc;&#130;&not;`, `–` → `&acirc;&#128;&#147;`). The JS engine does not decode entities in script content, so the corrupted inline JS (WooCommerce archive localized scripts, currency symbols, etc.) becomes invalid and throws a console syntax error, which in turn breaks dependent JS such as the filter-sidebar widget and collapses the layout.

Reproduced standalone (PHP 8.3 / libxml 2.12) with an inline WC-style script containing multibyte UTF-8:

```
ORIG: var wc_params = {"symbol":"€","msg":"Prixfestlegung – naïve"}; var cmp = (a < b) && (c > d);
UNP : var wc_params = {"symbol":"&acirc;&#130;&not;","msg":"Prixfestlegung &acirc;&#128;&#147; nai&Igrave;&#136;ve"}; var cmp = (a < b) && (c > d);
PRO : var wc_params = {"symbol":"€","msg":"Prixfestlegung – naïve"}; var cmp = (a < b) && (c > d);
```

`UNP` (unprotected) is corrupted; `PRO` (this fix) is byte-identical to the original.

## The fix

`modules/remediation/components/remediation-runner.php`
- Before `loadHTML()`, extract every inline `<script>…</script>` and `<style>…</style>` block and replace each with a unique placeholder comment (`<!--EA11YPROTECTN-->`), storing the original block.
- After `saveHTML()`, restore the original blocks verbatim into the placeholder positions.
- Ally's own injected assets (the `window.AllyRemediations` JSON script, `remediation-module.js`, and the STYLES remediation `<style>`) are created after `loadHTML()` and are unaffected — their content is already safe (`wp_json_encode` with `JSON_HEX_TAG | JSON_HEX_AMP | …`), so behavior for them is unchanged.

This is surgical: it preserves the page's existing inline JS/CSS exactly as the server emitted it, regardless of how libxml would otherwise mangle it.

## Cache invalidation

The corrupted output is persisted in `ea11y_page_scanned.full_html` and served to logged-out visitors while `is_valid_hash()` holds. To avoid serving stale corrupted HTML after deploy:

`modules/remediation/classes/utils.php` / `modules/remediation/database/page-entry.php`
- Introduced `Utils::HTML_CACHE_VERSION` and `Utils::get_cache_hash()` (a versioned `md5`), used by both `Page_Entry::update_html()` (writes) and `is_valid_hash()` (validation).
- Bumping `HTML_CACHE_VERSION` makes every previously cached hash mismatch on the next request, so each page lazily regenerates with the fixed pipeline and re-caches clean HTML. Self-healing, no activation hook required.

## Validation

- `php -l` passes on all three changed PHP files.
- Standalone round-trip tests confirm inline `<script>`/`<style>` blocks are preserved verbatim with the fix, including multibyte UTF-8, JSON-LD, comment-opened scripts, CSS child combinators, and empty/src-only scripts. No leftover placeholders in output.
- Note: the full PHPUnit suite (`npm run local:phpunit`) requires the Docker-based `@wordpress/env`, which is not available in this environment; no existing test covers `Remediation_Runner` directly. A follow-up to add a `Remediation_Runner` test (round-trip preserves inline scripts) is recommended.

## Out of scope / follow-up

- The same `loadHTML()`/`saveHTML()` round-trip also mangles multibyte UTF-8 in **visible body text** (not just scripts). Fixing that cleanly requires an encoding hint (e.g. `<?xml encoding="UTF-8">` prefix) and is a broader, riskier change; it is intentionally left for a separate ticket.
- Consider adding PHPUnit coverage for `Remediation_Runner::generate_remediation_dom()`.

## Jira

[APP-3016](https://elementor.atlassian.net/browse/APP-3016)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d60e093-387f-463c-a8c0-d4388c256bb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d60e093-387f-463c-a8c0-d4388c256bb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[APP-3016]: https://elementor.atlassian.net/browse/APP-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-3016]: https://elementor.atlassian.net/browse/APP-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ