### PR TITLE
Release v4.1.4 – fix inline script/style DOM round-trip (APP-3016)

### DIFF
--- a/modules/remediation/classes/utils.php
+++ b/modules/remediation/classes/utils.php
@@ -140,6 +140,25 @@ class Utils {
 		return md5( $text );
 	}
 
+	/**
+	 * Version salt for the rendered-HTML cache (Page_Entry::FULL_HTML).
+	 *
+	 * Bump this whenever the remediation rendering pipeline changes so that
+	 * previously cached HTML is treated as stale and regenerated on the next
+	 * request instead of being served as-is.
+	 */
+	const HTML_CACHE_VERSION = '2';
+
+	/**
+	 * Versioned hash used to validate cached rendered HTML.
+	 *
+	 * @param string $text
+	 * @return string
+	 */
+	public static function get_cache_hash( $text ) : string {
+		return md5( self::HTML_CACHE_VERSION . $text );
+	}
+
 	public static function trigger_save_for_clean_cache( $entry_id, $entry_type ): void {
 		$entry_id = (int) $entry_id;
 		$post_types = get_post_types([

--- a/modules/remediation/classes/utils.php
+++ b/modules/remediation/classes/utils.php
@@ -136,10 +136,6 @@ class Utils {
 		return 'unknown';
 	}
 
-	public static function get_hash( $text ) : string {
-		return md5( $text );
-	}
-
 	/**
 	 * Version salt for the rendered-HTML cache (Page_Entry::FULL_HTML).
 	 *

--- a/modules/remediation/components/remediation-runner.php
+++ b/modules/remediation/components/remediation-runner.php
@@ -238,8 +238,17 @@ class Remediation_Runner {
 	}
 
 	private function generate_remediation_dom( $buffer ): string {
+		// Inline <script> and <style> blocks are not round-trip safe through
+		// DOMDocument::loadHTML()/saveHTML(): libxml entity-encodes characters
+		// such as `<`, `>`, and `&` inside them, which corrupts inline
+		// JavaScript (e.g. WooCommerce archive scripts) and surfaces as a
+		// console syntax error that breaks the page layout. Stash them as
+		// placeholder comments before parsing and restore the original markup
+		// verbatim after serialization.
+		[ $protected_buffer, $placeholders ] = $this->stash_inline_assets( $buffer );
+
 		$dom = new DOMDocument( '1.0', 'UTF-8' );
-		$dom->loadHTML( $buffer, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOERROR );
+		$dom->loadHTML( $protected_buffer, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOERROR );
 
 		//Remove admin-bar for correct replace
 		$admin_bar = $dom->getElementById( 'wpadminbar' );
@@ -302,7 +311,58 @@ class Remediation_Runner {
 				$head->appendChild( $module_script );
 			}
 		}
-		return $dom->saveHTML();
+		return $this->restore_inline_assets( $dom->saveHTML(), $placeholders );
+	}
+
+	/**
+	 * Replace inline <script> and <style> blocks with placeholder comments
+	 * so their contents survive the DOMDocument load/save round-trip intact.
+	 *
+	 * @param string $buffer Raw page HTML.
+	 * @return array{0:string,1:array<string,string>} Protected buffer and map of placeholder keys to original blocks.
+	 */
+	private function stash_inline_assets( string $buffer ): array {
+		$placeholders = [];
+		$pattern       = '/<(script|style)\b[^>]*>.*?<\/\1>/is';
+
+		$protected = preg_replace_callback(
+			$pattern,
+			static function ( $matches ) use ( &$placeholders ) {
+				$key                 = 'EA11YPROTECT' . count( $placeholders );
+				$placeholders[ $key ] = $matches[0];
+				return '<!--' . $key . '-->';
+			},
+			$buffer
+		);
+
+		return [ null === $protected ? $buffer : (string) $protected, $placeholders ];
+	}
+
+	/**
+	 * Restore the original inline <script> and <style> blocks that were
+	 * replaced with placeholder comments by stash_inline_assets().
+	 *
+	 * @param string                $html         Serialized HTML from DOMDocument::saveHTML().
+	 * @param array<string,string>  $placeholders Map of placeholder keys to original blocks.
+	 * @return string
+	 */
+	private function restore_inline_assets( string $html, array $placeholders ): string {
+		foreach ( $placeholders as $key => $original ) {
+			$pattern  = '/<!--\s*' . preg_quote( $key, '/' ) . '\s*-->/';
+			$replaced = preg_replace_callback(
+				$pattern,
+				static function () use ( $original ) {
+					return $original;
+				},
+				$html,
+				1
+			);
+			if ( null !== $replaced ) {
+				$html = (string) $replaced;
+			}
+		}
+
+		return $html;
 	}
 
 	private function add_frontend_remediation( $remediation ) {

--- a/modules/remediation/database/page-entry.php
+++ b/modules/remediation/database/page-entry.php
@@ -54,7 +54,7 @@ class Page_Entry extends Entry {
 			return null;
 		}
 
-		$this->entry_data[ Page_Table::HASH ] = Utils::get_hash( $this->entry_data[ Page_Table::UPDATED_AT ] );
+		$this->entry_data[ Page_Table::HASH ] = Utils::get_cache_hash( $this->entry_data[ Page_Table::UPDATED_AT ] );
 		$this->entry_data[ Page_Table::FULL_HTML ] = $html;
 
 		$this->save();
@@ -121,7 +121,7 @@ class Page_Entry extends Entry {
 	 * @return bool
 	 */
 	public function is_valid_hash() : bool {
-		$current_hash = Utils::get_hash( $this->entry_data[ Page_Table::UPDATED_AT ] );
+		$current_hash = Utils::get_cache_hash( $this->entry_data[ Page_Table::UPDATED_AT ] );
 		return ! empty( $this->entry_data[ Page_Table::HASH ] ) && $this->entry_data[ Page_Table::HASH ] === $current_hash;
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pojo-accessibility",
 	"description": "",
-	"version": "4.1.3",
+	"version": "4.1.4",
 	"scripts": {
 		"build": "NODE_ENV=production wp-scripts build",
 		"start": "NODE_ENV=development wp-scripts start",

--- a/pojo-accessibility.php
+++ b/pojo-accessibility.php
@@ -5,7 +5,7 @@
  * Description: Improve your website’s accessibility with ease. Customize capabilities such as text resizing, contrast modes, link highlights, and easily generate an accessibility statement to demonstrate your commitment to inclusivity.
  * Author: Elementor.com
  * Author URI: https://elementor.com/
- * Version: 4.1.3
+ * Version: 4.1.4
  * Text Domain: pojo-accessibility
  *
  * Web Accessibility is free software: you can redistribute it and/or modify
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Legacy
 define( 'POJO_A11Y_CUSTOMIZER_OPTIONS', 'pojo_a11y_customizer_options' );
-define( 'EA11Y_VERSION', '4.1.3' );
+define( 'EA11Y_VERSION', '4.1.4' );
 define( 'EA11Y_MAIN_FILE', __FILE__ );
 define( 'EA11Y_BASE', plugin_basename( EA11Y_MAIN_FILE ) );
 define( 'EA11Y_PATH', plugin_dir_path( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,10 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Scanner dashboard: Track your site's accessibility scans, monitor open issues, and follow progress over time.
 
 == Changelog ==
+= 4.1.4 – Unreleased =
+* Fix: Prevented the remediation runner from corrupting inline `<script>` and `<style>` blocks (e.g. WooCommerce archive scripts with multibyte characters) during the DOMDocument round-trip, which caused console syntax errors and broken page layouts
+* Tweak: Versioned the rendered-HTML cache so previously cached (potentially corrupted) HTML is regenerated after the rendering pipeline changes
+
 = 4.1.3 – 2026-06-29 =
 * Tweak: Widget button custom position alignment
 * Tweak: Ally AI fixes improvments

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Web Accessibility, Accessibility, A11Y, WCAG, Accessibility Statement
 Requires at least: 6.7
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 4.1.3
+Stable tag: 4.1.4
 License: GPLv2 or later
 
 Web Accessibility (formally known as Ally) is a free, powerful, and user-friendly plugin that helps WordPress creators build more accessible websites with ease.
@@ -187,7 +187,7 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 7. Scanner dashboard: Track your site's accessibility scans, monitor open issues, and follow progress over time.
 
 == Changelog ==
-= 4.1.4 – Unreleased =
+= 4.1.4 – 2026-07-30 =
 * Fix: Prevented the remediation runner from corrupting inline `<script>` and `<style>` blocks (e.g. WooCommerce archive scripts with multibyte characters) during the DOMDocument round-trip, which caused console syntax errors and broken page layouts
 * Tweak: Versioned the rendered-HTML cache so previously cached (potentially corrupted) HTML is regenerated after the rendering pipeline changes
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release **4.1.4** with the remediation fix from [#574](https://github.com/elementor/one-click-accessibility/pull/574), including review feedback to replace `Utils::get_hash()` with `Utils::get_cache_hash()`.

Fixes [APP-3016](https://elementor.atlassian.net/browse/APP-3016): WooCommerce product archive pages with filter sidebars broke once Ally was active (layout collapse, console syntax errors).

## Changes

- **Remediation runner**: Stash inline `<script>` and `<style>` blocks as placeholder comments before `DOMDocument::loadHTML()` and restore them verbatim after `saveHTML()`, preventing libxml from entity-encoding multibyte UTF-8 inside inline JS/CSS.
- **Cache invalidation**: Introduced `Utils::HTML_CACHE_VERSION` and `Utils::get_cache_hash()`; removed `Utils::get_hash()`. Previously cached (potentially corrupted) HTML is regenerated on the next request.
- **Version bump**: `4.1.3` → `4.1.4` in `pojo-accessibility.php`, `package.json`, and `readme.txt`.

## Jira

[APP-3016](https://elementor.atlassian.net/browse/APP-3016)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f62a9573-4f10-459b-9b1b-bc88f0b2240a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f62a9573-4f10-459b-9b1b-bc88f0b2240a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[APP-3016]: https://elementor.atlassian.net/browse/APP-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-3016]: https://elementor.atlassian.net/browse/APP-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ