### PR TITLE
fix(ci): upgrade WPCS to 3.4.1 to unblock composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
 	"require-dev": {
 		"johnpbloch/wordpress-core": "^6.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
-		"squizlabs/php_codesniffer": "^3.6",
-		"wp-coding-standards/wpcs": "^2.3.0",
+		"squizlabs/php_codesniffer": "^3.13.5",
+		"wp-coding-standards/wpcs": "^3.4.1",
 		"php-stubs/wordpress-stubs": "^6.0",
 		"elementor/eunit": "^0.0.10",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -26,6 +26,7 @@
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 		<exclude name="Generic.Formatting.MultipleStatementAlignment" />
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
 		<exclude name="Generic.Functions.CallTimePassByReference" />
 		<exclude name="Squiz.Commenting.ClassComment.Missing" />
 		<exclude name="Squiz.Commenting.FileComment.Missing" />
@@ -37,6 +38,7 @@
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd" />
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterEnd" />
 		<exclude name="Squiz.WhiteSpace.LanguageConstructSpacing" />
+		<exclude name="Generic.WhiteSpace.LanguageConstructSpacing" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals" />
 		<exclude name="WordPress.WP.I18n" />
@@ -47,7 +49,7 @@
 
 	<rule ref="WordPress.WP.DeprecatedFunctions">
 		<properties>
-			<property name="minimum_supported_version" value="6.6" />
+			<property name="minimum_wp_version" value="6.6" />
 		</properties>
 	</rule>
 

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -45,6 +45,7 @@
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
+		<exclude name="PSR12.Functions.ReturnTypeDeclaration" />
 	</rule>
 
 	<rule ref="WordPress.WP.DeprecatedFunctions">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes CI failures blocking #574 (and other PRs): Composer now rejects `wp-coding-standards/wpcs ^2.3.0` due to [GHSA-3pwp-g2mj-5p3v](https://github.com/advisories/GHSA-3pwp-g2mj-5p3v) (CVE-2026-45293), causing PHP Lint, Build, and PHPUnit to fail at `composer install`.

- Upgrade `wp-coding-standards/wpcs` to `^3.4.1` and `squizlabs/php_codesniffer` to `^3.13.5`
- Update `ruleset.xml` for WordPressCS 3.x sniff renames
- Exclude `PSR12.Functions.ReturnTypeDeclaration` to avoid a repo-wide return-type reformat

No functional/plugin changes. Once merged, #574 should pass CI on re-run.

## Related

- #574
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb3a3-dee6-71a0-8ba4-28a76229a2d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb3a3-dee6-71a0-8ba4-28a76229a2d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[APP-3016]: https://elementor.atlassian.net/browse/APP-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

WPCS 2.3.0 incompatible with PHP CodeSniffer 3.6; upgrading to WPCS 3.4.1 fixes composer install failures.

## 2. What Changed (Where)

- **composer.json**: PHP CodeSniffer `^3.6` → `^3.13.5`; WPCS `^2.3.0` → `^3.4.1`
- **ruleset.xml**: Added 4 exclusions for WPCS 3.4.1 ruleset changes; renamed `minimum_supported_version` property to `minimum_wp_version`

## 3. How It Works

WPCS 3.4.1 introduced new rule namespaces (`Universal.*`, `Generic.WhiteSpace.*`, `PSR12.*`) and property name changes. Exclusions suppress new checks incompatible with project standards; property rename aligns with WPCS API.

## 4. Risks

Minimal. Version constraints are compatible ranges; exclusions are additive. Verify no excluded rules were intentional governance gaps before merging.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
